### PR TITLE
fix: configuration cannot parse URL with leading spaces.

### DIFF
--- a/src/ProxyParsers.js
+++ b/src/ProxyParsers.js
@@ -3,6 +3,7 @@ import { parseServerInfo, parseUrlParams, createTlsConfig, createTransportConfig
 
 export class ProxyParser {
 	static parse(url) {
+		url = url.trim();
 		const type = url.split('://')[0];
 		switch(type) {
 			case 'ss': return new ShadowsocksParser().parse(url);


### PR DESCRIPTION
fix url can not be parsed with leading spaces
