### PR TITLE
feat: add keyword filters for node subscription

### DIFF
--- a/docs/API-doc.md
+++ b/docs/API-doc.md
@@ -24,6 +24,7 @@ https://your-worker-domain.workers.dev
 - **方法**: GET
 - **参数**:
   - `config` (必需): URL 编码的字符串,包含一个或多个代理配置
+  - `filters` (可选): 一个或多个关键词,用逗号分隔,用于过滤包含关键词的节点,不支持正则表达式
   - `selectedRules` (可选): 预定义规则集名称或自定义规则的 JSON 数组
   - `customRules` (可选): 自定义规则的 JSON 数组
   - `pin` (可选): 布尔值，是否将自定义规则置于预定义规则之上

--- a/src/ClashConfigBuilder.js
+++ b/src/ClashConfigBuilder.js
@@ -4,11 +4,14 @@ import { BaseConfigBuilder } from './BaseConfigBuilder.js';
 import { DeepCopy } from './utils.js';
 
 export class ClashConfigBuilder extends BaseConfigBuilder {
-    constructor(inputString, selectedRules, customRules, pin, baseConfig) {
+    constructor(inputString, filters, selectedRules, customRules, pin, baseConfig) {
         if (!baseConfig) {
             baseConfig = CLASH_CONFIG
         }
-        super(inputString, baseConfig);
+        if (!filters) {
+            filters = [];
+        }
+        super(inputString, filters ,baseConfig);
         this.selectedRules = selectedRules;
         this.customRules = customRules;
         this.pin = pin;

--- a/src/SingboxConfigBuilder.js
+++ b/src/SingboxConfigBuilder.js
@@ -3,11 +3,14 @@ import { BaseConfigBuilder } from './BaseConfigBuilder.js';
 import { DeepCopy } from './utils.js';
 
 export class ConfigBuilder extends BaseConfigBuilder {
-    constructor(inputString, selectedRules, customRules, pin, baseConfig) {
+    constructor(inputString, filters, selectedRules, customRules, pin, baseConfig) {
         if (baseConfig === undefined) {
-            baseConfig = SING_BOX_CONFIG
+            baseConfig = SING_BOX_CONFIG;
         }
-        super(inputString, baseConfig);
+        if (!filters) {
+            filters = [];
+        }
+        super(inputString, filters ,baseConfig);
         this.selectedRules = selectedRules;
         this.customRules = customRules;
         this.pin = pin;

--- a/src/htmlBuilder.js
+++ b/src/htmlBuilder.js
@@ -78,6 +78,8 @@ const generateForm = () => `
     <div class="form-section">
       <div class="form-section-title">Share URLs</div>
       <textarea class="form-control" id="inputTextarea" name="input" required placeholder="vmess://abcd..." rows="3"></textarea>
+      <div class="form-section-title" style="margin-top:1rem;">Filter Keywords</div>
+      <textarea class="form-control" id="inputFilter" name="filters" placeholder="剩余,官网,到期" rows="1"></textarea>    
     </div>
 
     <div class="form-check form-switch mb-3">
@@ -468,9 +470,11 @@ const submitFormFunction = () => `
     const form = event.target;
     const formData = new FormData(form);
     const inputString = formData.get('input');
+    const filters = formData.get('filters') ? formData.get('filters').split(',') : '';
     
     // Save form data to localStorage
     localStorage.setItem('inputTextarea', inputString);
+    localStorage.setItem('inputFilter', filters);
     localStorage.setItem('advancedToggle', document.getElementById('advancedToggle').checked);
     localStorage.setItem('crpinToggle', document.getElementById('crpinToggle').checked);
     
@@ -503,9 +507,14 @@ const submitFormFunction = () => `
 
     const configParam = configId ? \`&configId=\${configId}\` : '';
     const xrayUrl = \`\${window.location.origin}/xray?config=\${encodeURIComponent(inputString)}\${configParam}\`;
-    const singboxUrl = \`\${window.location.origin}/singbox?config=\${encodeURIComponent(inputString)}&selectedRules=\${encodeURIComponent(JSON.stringify(selectedRules))}&customRules=\${encodeURIComponent(JSON.stringify(customRules))}&pin=\${pin}\${configParam}\`;
-    const clashUrl = \`\${window.location.origin}/clash?config=\${encodeURIComponent(inputString)}&selectedRules=\${encodeURIComponent(JSON.stringify(selectedRules))}&customRules=\${encodeURIComponent(JSON.stringify(customRules))}&pin=\${pin}\${configParam}\`;
-
+    let singboxUrl, clashUrl;
+    if (filters.length > 0) {
+      singboxUrl = \`\${window.location.origin}/singbox?config=\${encodeURIComponent(inputString)}&filters=\${encodeURIComponent(JSON.stringify(filters))}&selectedRules=\${encodeURIComponent(JSON.stringify(selectedRules))}&customRules=\${encodeURIComponent(JSON.stringify(customRules))}&pin=\${pin}\${configParam}\`;
+      clashUrl = \`\${window.location.origin}/clash?config=\${encodeURIComponent(inputString)}&filters=\${encodeURIComponent(JSON.stringify(filters))}&selectedRules=\${encodeURIComponent(JSON.stringify(selectedRules))}&customRules=\${encodeURIComponent(JSON.stringify(customRules))}&pin=\${pin}\${configParam}\`;
+    } else {
+      singboxUrl = \`\${window.location.origin}/singbox?config=\${encodeURIComponent(inputString)}&selectedRules=\${encodeURIComponent(JSON.stringify(selectedRules))}&customRules=\${encodeURIComponent(JSON.stringify(customRules))}&pin=\${pin}\${configParam}\`;
+      clashUrl = \`\${window.location.origin}/clash?config=\${encodeURIComponent(inputString)}&selectedRules=\${encodeURIComponent(JSON.stringify(selectedRules))}&customRules=\${encodeURIComponent(JSON.stringify(customRules))}&pin=\${pin}\${configParam}\`;
+    }
     document.getElementById('xrayLink').value = xrayUrl;
     document.getElementById('singboxLink').value = singboxUrl;
     document.getElementById('clashLink').value = clashUrl;
@@ -523,6 +532,11 @@ const submitFormFunction = () => `
     const savedInput = localStorage.getItem('inputTextarea');
     if (savedInput) {
       document.getElementById('inputTextarea').value = savedInput;
+    }
+    
+    const savedFilter = localStorage.getItem('inputFilter');
+    if (savedFilter) {
+      document.getElementById('inputFilter').value = savedFilter;
     }
 
     const advancedToggle = localStorage.getItem('advancedToggle');
@@ -579,6 +593,7 @@ const submitFormFunction = () => `
 
   function clearFormData() {
     localStorage.removeItem('inputTextarea');
+    localStorage.removeItem('inputFilter');
     localStorage.removeItem('advancedToggle');
     localStorage.removeItem('selectedRules');
     localStorage.removeItem('predefinedRules');
@@ -586,6 +601,7 @@ const submitFormFunction = () => `
     localStorage.removeItem('configType');    // 添加清除 configType
     
     document.getElementById('inputTextarea').value = '';
+    document.getElementById('inputFilter').value = '';
     document.getElementById('advancedToggle').checked = false;
     document.getElementById('advancedOptions').classList.remove('show');
     document.getElementById('configEditor').value = '';


### PR DESCRIPTION
The implementation is somewhat crude with a high degree of code coupling, which might require consideration regarding merging. These commits primarily introduce a keyword filtering feature for node subscriptions. The aim is to address issues similar to #32 and #42, allowing users to filter out nodes that are confirmed to be unable to connect to the internet. This helps avoid problems like rule download failures during the first startup.