### PR TITLE
修复服务器名称解析中存在的问题

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -126,9 +126,12 @@ export function parseServerInfo(serverInfo) {
 	const [paramsOnly, ...fragmentParts] = paramsPart.split('#');
 	const searchParams = new URLSearchParams(paramsOnly);
 	const params = Object.fromEntries(searchParams.entries());
-  
-	const name = fragmentParts.length > 0 ? decodeURIComponent(fragmentParts.join('#')) : '';
-  
+
+	let name = fragmentParts.length > 0 ? fragmentParts.join('#') : '';
+	try {
+	    name = decodeURIComponent(name);
+	} catch (error) { };
+	
 	return { addressPart, params, name };
   }
   


### PR DESCRIPTION
当服务器名称末尾包含%字符时会导致parseUrlParams出错，从而导致无法正常转换。