### PR TITLE
fix: fix sing-box clash_mode global outbound

### DIFF
--- a/src/SingboxConfigBuilder.js
+++ b/src/SingboxConfigBuilder.js
@@ -102,7 +102,7 @@ export class SingboxConfigBuilder extends BaseConfigBuilder {
         this.config.route.rules.unshift(
             { protocol: 'dns', outbound: 'dns-out' },
             { clash_mode: 'direct', outbound: 'DIRECT' },
-            { clash_mode: 'global', outbound: 'GLOBAL' }
+            { clash_mode: 'global', outbound: t('outboundNames.Node Select') }
         );
 
         this.config.route.auto_detect_interface = true;


### PR DESCRIPTION
现有的sing-box配置文件中全局模式对应的`clash_mode`使用名为`GLOBAL`的出站，实际上不存在于配置文件中。当用户希望使用**全局代理**时，该`clash_mode`时会找不到出站，所以要么添加一个`GLOBAL`出站，要么将该clash_mode指向现存的出站，这里为了避免规则模式下的用户困惑，这个PR直接将该`clash_mode`指向`outboundNames.Node Select`出站。