### PR TITLE
fix: TLS: take care of irregular tls configs

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -147,7 +147,7 @@ export function parseServerInfo(serverInfo) {
   
   export function createTlsConfig(params) {
 	let tls = { enabled: false };
-	if (params.security === 'xtls' || params.security === 'tls' || params.security === 'reality') {
+	if (params.security != 'none') {
 	  tls = {
 		enabled: true,
 		server_name: params.sni || params.host,


### PR DESCRIPTION
某些情况下，对于使用TLS传输层加密的协议（Trojan、Vless）可能存在了`sni`等配置存在但缺省`security`字段的情况，这在使用*Ray形式订阅的客户端（如V2RayNG、 V2flyNG、 NekoBox等）上通常不会引起问题，因为缺省`security`字段的默认行为是启用TLS加密，除非手动指定`security`为`none`。

事实上，由于Trojan被设计工作在正确加密的TLS隧道中，不启用加密的极少数使用场景下应由用户主动指定`security`为`none`。此PR使sublink行为同上述*Ray订阅客户端保持一致。

另：我注意到sublink在`createTlsConfig()`、 `VmessParser`、`Hysteria2Parser`等处将`insecure`  `up_mbps` `down_mbps`等值hardcode为了特定值而不是从订阅链接提取，这种写法有什么特定目的吗？