### PR TITLE
fix: surge: add vmess-aead if alter_id is 0

### DIFF
--- a/src/SurgeConfigBuilder.js
+++ b/src/SurgeConfigBuilder.js
@@ -61,6 +61,9 @@ export class SurgeConfigBuilder extends BaseConfigBuilder {
                 break;
             case 'vmess':
                 surgeProxy = `${proxy.tag} = vmess, ${proxy.server}, ${proxy.server_port}, username=${proxy.uuid}`;
+                if (proxy.alter_id == 0) {
+                    surgeProxy += ', vmess-aead=true';
+                }
                 if (proxy.tls?.enabled) {
                     surgeProxy += ', tls=true';
                     if (proxy.tls.server_name) {


### PR DESCRIPTION
对于Vmess协议，在 v4.28.1 版本后，客户端 `AlterID` 设置为 `0` 代表启用 VMessAEAD ，然而对于Surge客户端而言并无此项配置，取而代之的是订阅中携带`vmess-aead`，此PR使Vmess订阅`alter_id`为`0`时，向Surge配置文件中添加`vmess-aead = true`以便该客户端能够正常使用。