### PR TITLE
fix: sing-box: clash: surge: better rule-set sorting

### DIFF
--- a/src/SingboxConfigBuilder.js
+++ b/src/SingboxConfigBuilder.js
@@ -87,17 +87,42 @@ export class SingboxConfigBuilder extends BaseConfigBuilder {
 
         this.config.route.rule_set = [...site_rule_sets, ...ip_rule_sets];
 
-        this.config.route.rules = rules.map(rule => ({
-            rule_set: [
-              ...(rule.site_rules.length > 0 && rule.site_rules[0] !== '' ? rule.site_rules : []),
-              ...(rule.ip_rules.filter(ip => ip.trim() !== '').map(ip => `${ip}-ip`))
-            ],
-            domain_suffix: rule.domain_suffix,
-            domain_keyword: rule.domain_keyword,
-            ip_cidr: rule.ip_cidr,
-            protocol: rule.protocol,
-            outbound: t(`outboundNames.${rule.outbound}`)
-        }));
+        rules.filter(rule => !!rule.domain_suffix || !!rule.domain_keyword).map(rule => {
+            this.config.route.rules.push({
+                domain_suffix: rule.domain_suffix,
+                domain_keyword: rule.domain_keyword,
+                protocol: rule.protocol,
+                outbound: t(`outboundNames.${rule.outbound}`)
+            });
+        });
+
+        rules.filter(rule => !!rule.site_rules[0]).map(rule => {
+            this.config.route.rules.push({
+                rule_set: [
+                ...(rule.site_rules.length > 0 && rule.site_rules[0] !== '' ? rule.site_rules : []),
+                ],
+                protocol: rule.protocol,
+                outbound: t(`outboundNames.${rule.outbound}`)
+            });
+        });
+
+        rules.filter(rule => !!rule.ip_rules[0]).map(rule => {
+            this.config.route.rules.push({
+                rule_set: [
+                ...(rule.ip_rules.filter(ip => ip.trim() !== '').map(ip => `${ip}-ip`))
+                ],
+                protocol: rule.protocol,
+                outbound: t(`outboundNames.${rule.outbound}`)
+          });
+        });
+
+        rules.filter(rule => !!rule.ip_cidr).map(rule => {
+            this.config.route.rules.push({
+                ip_cidr: rule.ip_cidr,
+                protocol: rule.protocol,
+                outbound: t(`outboundNames.${rule.outbound}`)
+            });
+        });
 
         this.config.route.rules.unshift(
             { protocol: 'dns', outbound: 'dns-out' },

--- a/src/SurgeConfigBuilder.js
+++ b/src/SurgeConfigBuilder.js
@@ -227,57 +227,59 @@ export class SurgeConfigBuilder extends BaseConfigBuilder {
         }
 
         finalConfig.push('\n[Rule]');
-        rules.forEach(rule => {
-            if (rule.site_rules[0] !== '') {
-                rule.site_rules.forEach(site => {
-                    switch (site.toLowerCase()) {
-                        case 'cn':
-                            finalConfig.push(`DOMAIN-SUFFIX,cn,${t('outboundNames.'+ rule.outbound)}`);
-                            finalConfig.push(`DOMAIN-SUFFIX,com.cn,${t('outboundNames.'+ rule.outbound)}`);
-                            finalConfig.push(`DOMAIN-SUFFIX,edu.cn,${t('outboundNames.'+ rule.outbound)}`);
-                            finalConfig.push(`DOMAIN-SUFFIX,gov.cn,${t('outboundNames.'+ rule.outbound)}`);
-                            break;
-                        case 'google':
-                            finalConfig.push(`DOMAIN-SUFFIX,google.com,${t('outboundNames.'+ rule.outbound)}`);
-                            finalConfig.push(`DOMAIN-SUFFIX,googleapis.com,${t('outboundNames.'+ rule.outbound)}`);
-                            finalConfig.push(`DOMAIN-SUFFIX,googlevideo.com,${t('outboundNames.'+ rule.outbound)}`);
-                            finalConfig.push(`DOMAIN-KEYWORD,google,${t('outboundNames.'+ rule.outbound)}`);
-                            break;
-                        case 'telegram':
-                            finalConfig.push(`DOMAIN-SUFFIX,telegram.org,${t('outboundNames.'+ rule.outbound)}`);
-                            finalConfig.push(`DOMAIN-SUFFIX,telegram.me,${t('outboundNames.'+ rule.outbound)}`);
-                            finalConfig.push(`DOMAIN-SUFFIX,t.me,${t('outboundNames.'+ rule.outbound)}`);
-                            finalConfig.push(`DOMAIN-KEYWORD,telegram,${t('outboundNames.'+ rule.outbound)}`);
-                            break;
-                        default:
-                            finalConfig.push(`DOMAIN-KEYWORD,${site},${t('outboundNames.'+ rule.outbound)}`);
-                    }
-                });
-            }
 
-            if (rule.ip_rules[0] !== '') {
-                rule.ip_rules.forEach(ip => {
-                    finalConfig.push(`GEOIP,${ip},${t('outboundNames.'+ rule.outbound)},no-resolve`);
-                });
-            }
+        // Rule-Set & Domain Rules & IP Rules:  To reduce DNS leaks and unnecessary DNS queries,
+        // domain & non-IP rules must precede IP rules
 
-            if (rule.domain_suffix) {
-                rule.domain_suffix.forEach(suffix => {
-                    finalConfig.push(`DOMAIN-SUFFIX,${suffix},${t('outboundNames.'+ rule.outbound)}`);
-                });
-            }
+        rules.filter(rule => !!rule.domain_suffix).map(rule => {
+            rule.domain_suffix.forEach(suffix => {
+                finalConfig.push(`DOMAIN-SUFFIX,${suffix},${t('outboundNames.'+ rule.outbound)}`);
+            });
+        });
 
-            if (rule.domain_keyword) {
-                rule.domain_keyword.forEach(keyword => {
-                    finalConfig.push(`DOMAIN-KEYWORD,${keyword},${t('outboundNames.'+ rule.outbound)}`);
-                });
-            }
+        rules.filter(rule => !!rule.domain_keyword).map(rule => {
+            rule.domain_keyword.forEach(keyword => {
+                finalConfig.push(`DOMAIN-KEYWORD,${keyword},${t('outboundNames.'+ rule.outbound)}`);
+            });
+        });
 
-            if (rule.ip_cidr) {
-                rule.ip_cidr.forEach(cidr => {
-                    finalConfig.push(`IP-CIDR,${cidr},${t('outboundNames.'+ rule.outbound)},no-resolve`);
-                });
-            }
+        rules.filter(rule => rule.site_rules[0] !== '').map(rule => {
+            rule.site_rules.forEach(site => {
+                switch (site.toLowerCase()) {
+                    case 'cn':
+                        finalConfig.push(`DOMAIN-SUFFIX,cn,${t('outboundNames.'+ rule.outbound)}`);
+                        finalConfig.push(`DOMAIN-SUFFIX,com.cn,${t('outboundNames.'+ rule.outbound)}`);
+                        finalConfig.push(`DOMAIN-SUFFIX,edu.cn,${t('outboundNames.'+ rule.outbound)}`);
+                        finalConfig.push(`DOMAIN-SUFFIX,gov.cn,${t('outboundNames.'+ rule.outbound)}`);
+                        break;
+                    case 'google':
+                        finalConfig.push(`DOMAIN-SUFFIX,google.com,${t('outboundNames.'+ rule.outbound)}`);
+                        finalConfig.push(`DOMAIN-SUFFIX,googleapis.com,${t('outboundNames.'+ rule.outbound)}`);
+                        finalConfig.push(`DOMAIN-SUFFIX,googlevideo.com,${t('outboundNames.'+ rule.outbound)}`);
+                        finalConfig.push(`DOMAIN-KEYWORD,google,${t('outboundNames.'+ rule.outbound)}`);
+                        break;
+                    case 'telegram':
+                        finalConfig.push(`DOMAIN-SUFFIX,telegram.org,${t('outboundNames.'+ rule.outbound)}`);
+                        finalConfig.push(`DOMAIN-SUFFIX,telegram.me,${t('outboundNames.'+ rule.outbound)}`);
+                        finalConfig.push(`DOMAIN-SUFFIX,t.me,${t('outboundNames.'+ rule.outbound)}`);
+                        finalConfig.push(`DOMAIN-KEYWORD,telegram,${t('outboundNames.'+ rule.outbound)}`);
+                        break;
+                    default:
+                        finalConfig.push(`DOMAIN-KEYWORD,${site},${t('outboundNames.'+ rule.outbound)}`);
+                }
+            });
+        });
+
+        rules.filter(rule => rule.ip_rules[0] !== '').map(rule => {
+            rule.ip_rules.forEach(ip => {
+                finalConfig.push(`GEOIP,${ip},${t('outboundNames.'+ rule.outbound)},no-resolve`);
+            });
+        });
+
+        rules.filter(rule => !!rule.ip_cidr).map(rule => {
+            rule.ip_cidr.forEach(cidr => {
+                finalConfig.push(`IP-CIDR,${cidr},${t('outboundNames.'+ rule.outbound)},no-resolve`);
+            });
         });
 
         finalConfig.push('FINAL,' + t('outboundNames.Fall Back'));

--- a/src/config.js
+++ b/src/config.js
@@ -479,12 +479,7 @@ export const SING_BOX_CONFIG = {
                 "path": "geosite-geolocation-!cn.srs"
             }
 		],
-		rules: [
-			{
-				"outbound": "any",
-				"server": "dns_resolver"
-			}
-		]
+		rules: []
 	},
 	experimental: {
 		cache_file: {


### PR DESCRIPTION
> 在 Surge 和 Clash 中，规则自上而下匹配，只有当遇到 IP 类规则（如 IP-CIDR、IP-CIDR6、GEOIP 和 IP-ASN）时才会发起 DNS 解析。因此，在 Surge 中，将会触发 DNS 解析的规则放在域名和 URL 匹配规则后面非常重要。

对于sing-box、clash、surge，IP和域名类规则的排序相当重要，如果IP规则靠前则会提前触发DNS解析，此PR使规则及自定义规则中的域名类规则始终排在ip类规则前。

此外，此PR的提出是为了配合解决另外一个问题：配置文件中的`no-resolve`参数导致的分流异常。我关注到此前在[issue#93](https://github.com/7Sageer/sublink-worker/issues/93)中有提到向ip规则中添加`no-resolve`参数防止DNS解析的意见，此后在Commit [3b38e71](https://github.com/7Sageer/sublink-worker/commit/3b38e7177370d36687d87be128997212c78c75c1)中实施了相关更改。

然而此更改引起了一些问题：由于GeoSite本身难以覆盖所有CN域名，GeoIP CN这类IP规则的存在至关重要，对其添加`no-resolve`将会导致未被GeoSite覆盖但实际上仍位于CN的大量网站最终无法被正确分流。此问题对于**Surge**尤为严重，由于当前未使用和sing-box及clash类似的远程规则集，Surge的规则策略中没有使用geolocation-cn这样的域名规则，对于CN的分流完全依赖GeoIP规则，添加`no-resolve`直接导致了访问CN相关域名全部分流至FINAL。

建议考虑对GeoIP CN单独放行不添加`no-resolve`，或考虑均不添加，配合此PR，域名规则中的网站不会触发DNS解析，同时兼顾了分流准确度。