### PR TITLE
Sing-box: Bring back REJECT outbound to cope with sing-box changes

### DIFF
--- a/src/SingboxConfigBuilder.js
+++ b/src/SingboxConfigBuilder.js
@@ -56,12 +56,12 @@ export class SingboxConfigBuilder extends BaseConfigBuilder {
         this.config.outbounds.unshift({
             type: "urltest",
             tag: t('outboundNames.Auto Select'),
-            outbounds: DeepCopy(proxyList.filter(proxy => proxy !== t('outboundNames.DIRECT'))),
+            outbounds: DeepCopy(proxyList),
         });
     }
 
     addNodeSelectGroup(proxyList) {
-        proxyList.unshift('DIRECT', t('outboundNames.Auto Select'));
+        proxyList.unshift('DIRECT', 'REJECT', t('outboundNames.Auto Select'));
         this.config.outbounds.unshift({
             type: "selector",
             tag: t('outboundNames.Node Select'),

--- a/src/config.js
+++ b/src/config.js
@@ -464,12 +464,11 @@ export const SING_BOX_CONFIG = {
 	},
 	inbounds: [
 		{ type: 'mixed', tag: 'mixed-in', listen: '0.0.0.0', listen_port: 2080 },
-		{ type: 'tun', tag: 'tun-in', address: '172.19.0.1/30', auto_route: true, strict_route: true, stack: 'mixed', sniff: true },
-		{ "type": "socks", "listen": "127.0.0.1", "listen_port": 2081, "tag": "REJECT-in" },
+		{ type: 'tun', tag: 'tun-in', address: '172.19.0.1/30', auto_route: true, strict_route: true, stack: 'mixed', sniff: true }
 	],
 	outbounds: [
-		{ "type": "socks", "server": "127.0.0.1", "server_port": 2081, "tag": "REJECT" },
-		{ "type": "direct", "tag": "DIRECT" },
+		{ type: 'block', tag: 'REJECT' },
+		{ type: "direct", tag: 'DIRECT' }
 	],
 	route : {
 		"rule_set": [
@@ -480,16 +479,7 @@ export const SING_BOX_CONFIG = {
                 "path": "geosite-geolocation-!cn.srs"
             }
 		],
-		rules: [      
-			// {
-			// 	"inbound": ["REJECT-in"],
-			// 	"action": "reject"
-			// },
-			{
-				"inbound": ["DIRECT-in"],
-				"action": "direct"
-			}
-		]
+		rules: []
 	},
 	experimental: {
 		cache_file: {


### PR DESCRIPTION
如 #88 中的回复，sing-box 在 1.11.10 中暂时回退了废弃 `block` 出站的特性，我们不必再使用添加 `socks` 这一丑陋的方式进行广告屏蔽了，此PR回退部分[cc6356a](https://github.com/7Sageer/sublink-worker/commit/cc6356a82bc052c04093ec30581305b84837c2fa)中引入的更改，带回了传统的广告拦截方式。

注意：这个PR不应该立即被考虑合并，因为 sing-box 1.11.10 在此PR发出数小时前才释出，部分平台用户尚不能得到最新更新，建议于数天至一周后考虑合并～