### PR TITLE
FIX `ERR_PNPM_OUTDATED_LOCKFILE` error

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
-      sublink-plus:
-        specifier: 'file:'
-        version: 'file:'
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.8.0
@@ -3441,10 +3438,6 @@ snapshots:
   stoppable@1.1.0: {}
 
   strnum@1.0.5: {}
-
-  'sublink-plus@file:':
-    dependencies:
-      js-yaml: 4.1.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
 


### PR DESCRIPTION
[Commit 87fa418](https://github.com/7Sageer/sublink-worker/commit/87fa418b74559922050eb3de6817ad5ec750fbe6#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L19) removed the `"sublink-plus": "file:"` in `package.json`, but did not remove the corresponding content in `pnpm-lock.yaml` (possibly because it was ignored).

It caused an **ERR_PNPM_OUTDATED_LOCKFILE** error when installing dependencies.

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with <ROOT>/package.json

Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"

  Failure reason:
  specifiers in the lockfile don't match specifiers in package.json:
* 1 dependencies were removed: sublink-plus@file:
```