### PR TITLE
fix: Surge 配置验证报错 parseSurgeConfigInput is not defined

### DIFF
--- a/src/components/formLogic.js
+++ b/src/components/formLogic.js
@@ -1,7 +1,74 @@
-import { parseSurgeConfigInput } from '../utils/surgeConfigParser.js';
-
 export const formLogicFn = (t) => {
     window.formData = function () {
+        // Inline parseSurgeConfigInput to make it available in toString()
+        function parseSurgeValue(rawValue = '') {
+            const trimmed = rawValue.trim();
+            if (trimmed === '') return '';
+            const unquoted = trimmed.replace(/^"(.*)"$/, '$1');
+            const lower = unquoted.toLowerCase();
+            if (lower === 'true') return true;
+            if (lower === 'false') return false;
+            if (/^-?\d+(\.\d+)?$/.test(unquoted)) return Number(unquoted);
+            return unquoted;
+        }
+
+        function convertSurgeIniToJson(content) {
+            const lines = content.split(/\r?\n/);
+            const config = {};
+            let currentSection = null;
+            const ensureObject = (key) => {
+                if (!config[key]) config[key] = {};
+                return config[key];
+            };
+            const ensureArray = (key) => {
+                if (!config[key]) config[key] = [];
+                return config[key];
+            };
+            for (const rawLine of lines) {
+                const line = rawLine.trim();
+                if (!line || line.startsWith(';') || line.startsWith('#')) continue;
+                const sectionMatch = line.match(/^\[(.+)]$/);
+                if (sectionMatch) {
+                    currentSection = sectionMatch[1].trim();
+                    continue;
+                }
+                if (!currentSection) continue;
+                const sectionName = currentSection.toLowerCase();
+                if (sectionName === 'general' || sectionName === 'replica') {
+                    const equalsIndex = line.indexOf('=');
+                    if (equalsIndex === -1) continue;
+                    const key = line.slice(0, equalsIndex).trim();
+                    const value = line.slice(equalsIndex + 1).trim();
+                    if (!key) continue;
+                    const target = ensureObject(sectionName);
+                    target[key] = parseSurgeValue(value);
+                } else if (sectionName === 'proxy') {
+                    ensureArray('proxies').push(line);
+                } else if (sectionName === 'proxy group') {
+                    ensureArray('proxy-groups').push(line);
+                } else if (sectionName === 'rule') {
+                    ensureArray('rules').push(line);
+                } else {
+                    ensureArray(sectionName).push(line);
+                }
+            }
+            if (!config.general && !config.replica && !config.proxies && !config['proxy-groups']) {
+                throw new Error('Unable to parse Surge INI content');
+            }
+            return config;
+        }
+
+        function parseSurgeConfigInput(content) {
+            const trimmed = content.trim();
+            if (!trimmed) throw new Error('Config content is empty');
+            try {
+                return { configObject: JSON.parse(trimmed), convertedFromIni: false };
+            } catch {
+                const converted = convertSurgeIniToJson(content);
+                return { configObject: converted, convertedFromIni: true };
+            }
+        }
+
         return {
             input: '',
             showAdvanced: false,

--- a/test/formLogic.test.js
+++ b/test/formLogic.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { formLogicFn } from '../src/components/formLogic.js';
+
+describe('formLogic toString fix', () => {
+  it('includes parseSurgeConfigInput definition in toString output', () => {
+    const fnString = formLogicFn.toString();
+
+    // Verify the function references parseSurgeConfigInput
+    expect(fnString).toContain('parseSurgeConfigInput');
+
+    // Verify the function definition IS included
+    expect(fnString).toMatch(/function\s+parseSurgeConfigInput/);
+
+    // Verify helper functions are also included
+    expect(fnString).toMatch(/function\s+parseSurgeValue/);
+    expect(fnString).toMatch(/function\s+convertSurgeIniToJson/);
+  });
+});


### PR DESCRIPTION
## 问题

`formLogicFn` 通过 `toString()` 内联到浏览器端 HTML（`Form.jsx` 第44行）。`toString()` 只序列化函数体，不包含模块 `import`，导致 `parseSurgeConfigInput` 在浏览器运行时为 `undefined`。

## 修复

将 `parseSurgeValue`、`convertSurgeIniToJson`、`parseSurgeConfigInput` 三个函数内联到 `formLogicFn` 内部，确保 `toString()` 输出包含完整定义。

- `surgeConfigParser.js` 导出接口不变，其他引用不受影响
- 新增 `test/formLogic.test.js` 验证修复
- 全部 165 个测试通过

Fixes #329