### PR TITLE
fix: hysteria2 node only insecure param but tls required error

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -273,7 +273,7 @@ export function createTlsConfig(params) {
 	if (params.security && params.security !== 'none') {
 		tls = {
 			enabled: true,
-			server_name: params.sni || params.host,
+			server_name: params.sni || params.host || params.peer,
 			insecure: !!params?.allowInsecure || !!params?.insecure || !!params?.allow_insecure,
 			// utls: {
 			//   enabled: true,
@@ -287,6 +287,16 @@ export function createTlsConfig(params) {
 				short_id: params.sid,
 			};
 		}
+	} else if (params?.insecure || params?.allowInsecure || params?.allow_insecure) {
+		tls = {
+			enabled: true,
+			server_name: params.sni || params.host || params.peer,
+			insecure: !!params?.allowInsecure || !!params?.insecure || !!params?.allow_insecure,
+			// utls: {
+			//   enabled: true,
+			//   fingerprint: "chrome"
+			// },
+		};
 	}
 	return tls;
 }


### PR DESCRIPTION
try fix #340，使用 hysteria2 节点出现同样的问题，将如下节点链接解析成 sing-box 节点之后会报错 tls required。

```
hysteria2://password@ip:port?peer=xxxxxxxx&insecure=1#REMARK
```