### PR TITLE
fix: hysteria2 should default to TLS when security param is missing

### DIFF
--- a/src/parsers/protocols/hysteria2Parser.js
+++ b/src/parsers/protocols/hysteria2Parser.js
@@ -19,6 +19,8 @@ export function parseHysteria2(url) {
         password = params.auth;
     }
 
+    // Hysteria2 requires TLS by protocol design
+    if (!params.security) params.security = 'tls';
     const tls = createTlsConfig(params);
     const obfs = {};
     if (params['obfs-password']) {


### PR DESCRIPTION
Fixes #340

**Root cause**: Hysteria2 protocol requires TLS by design, but the parser doesn't set a default `security` value when parsing URIs. This causes `createTlsConfig()` to return `undefined`, leading to "TLS required" errors in sing-box.

**Fix**: Set `params.security = 'tls'` as default before calling `createTlsConfig()` in `hysteria2Parser.js`.

**Why not PR #344's approach**: That PR enables TLS based on the `insecure` parameter in `createTlsConfig()`, which is incorrect — `insecure` only means "skip certificate verification", not "enable TLS". That approach would affect other protocols (vmess/vless) that shouldn't have TLS enabled by default.

**Testing**: All 167 tests pass ✅