### PR TITLE
fix: remove legacy sniff field from tun inbound for sing-box 1.13.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
   <br>
 
 <p style="display: flex; align-items: center; gap: 10px;">
-  <a href="https://deploy.workers.cloudflare.com/?url=https://github.com/7Sageer/sublink-worker">
+  <a href="https://deploy.workers.cloudflare.com/?url=https://github.com/lizhi123le/sublink-worker">
     <img src="https://deploy.workers.cloudflare.com/button" alt="Deploy to Cloudflare Workers" style="height: 32px;"/>
   </a>
-  <a href="https://vercel.com/new/clone?repository-url=https://github.com/7Sageer/sublink-worker&env=KV_REST_API_URL,KV_REST_API_TOKEN&envDescription=Vercel%20KV%20credentials%20for%20data%20storage&envLink=https://vercel.com/docs/storage/vercel-kv">
+  <a href="https://vercel.com/new/clone?repository-url=https://github.com/lizhi123le/sublink-worker&env=KV_REST_API_URL,KV_REST_API_TOKEN&envDescription=Vercel%20KV%20credentials%20for%20data%20storage&envLink=https://vercel.com/docs/storage/vercel-kv">
     <img src="https://vercel.com/button" alt="Deploy to Vercel" style="height: 32px;"/>
   </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
   <br>
 
 <p style="display: flex; align-items: center; gap: 10px;">
-  <a href="https://deploy.workers.cloudflare.com/?url=https://github.com/lizhi123le/sublink-worker">
+  <a href="https://deploy.workers.cloudflare.com/?url=https://github.com/7Sageer/sublink-worker">
     <img src="https://deploy.workers.cloudflare.com/button" alt="Deploy to Cloudflare Workers" style="height: 32px;"/>
   </a>
-  <a href="https://vercel.com/new/clone?repository-url=https://github.com/lizhi123le/sublink-worker&env=KV_REST_API_URL,KV_REST_API_TOKEN&envDescription=Vercel%20KV%20credentials%20for%20data%20storage&envLink=https://vercel.com/docs/storage/vercel-kv">
+  <a href="https://vercel.com/new/clone?repository-url=https://github.com/7Sageer/sublink-worker&env=KV_REST_API_URL,KV_REST_API_TOKEN&envDescription=Vercel%20KV%20credentials%20for%20data%20storage&envLink=https://vercel.com/docs/storage/vercel-kv">
     <img src="https://vercel.com/button" alt="Deploy to Vercel" style="height: 32px;"/>
   </a>
 </p>

--- a/src/config/singboxConfig.js
+++ b/src/config/singboxConfig.js
@@ -23,7 +23,7 @@ export const SING_BOX_CONFIG = {
 				server: "localDns"
 			},
 			{
-				rule_set: "geosite-cn",
+				rule_set: "cn",
 				server: "localDns"
 			},
 			{
@@ -35,7 +35,7 @@ export const SING_BOX_CONFIG = {
 				server: "proxyDns"
 			},
 			{
-				rule_set: "geosite-geolocation-!cn",
+				rule_set: "geolocation-!cn",
 				server: "proxyDns"
 			}
 		],
@@ -59,10 +59,10 @@ export const SING_BOX_CONFIG = {
 	route: {
 		"rule_set": [
 			{
-				"tag": "geosite-geolocation-!cn",
+				"tag": "geolocation-!cn",
 				"type": "local",
 				"format": "binary",
-				"path": "geosite-geolocation-!cn.srs"
+				"path": "geolocation-!cn.srs"
 			}
 		],
 		rules: []
@@ -94,7 +94,7 @@ export const SING_BOX_CONFIG_V1_11 = {
 				server: "localDns"
 			},
 			{
-				rule_set: "geosite-cn",
+				rule_set: "cn",
 				server: "localDns"
 			},
 			{
@@ -106,7 +106,7 @@ export const SING_BOX_CONFIG_V1_11 = {
 				server: "proxyDns"
 			},
 			{
-				rule_set: "geosite-geolocation-!cn",
+				rule_set: "geolocation-!cn",
 				server: "proxyDns"
 			}
 		],

--- a/src/config/singboxConfig.js
+++ b/src/config/singboxConfig.js
@@ -14,7 +14,7 @@ export const SING_BOX_CONFIG = {
 			{
 				tag: "localDns",
 				address: "https://223.5.5.5/dns-query",
-				detour: "direct"
+				detour: "DIRECT"
 			}
 		],
 		rules: [
@@ -85,7 +85,7 @@ export const SING_BOX_CONFIG_V1_11 = {
 			{
 				tag: "localDns",
 				address: "https://223.5.5.5/dns-query",
-				detour: "direct"
+				detour: "DIRECT"
 			}
 		],
 		rules: [

--- a/src/config/singboxConfig.js
+++ b/src/config/singboxConfig.js
@@ -49,8 +49,30 @@ export const SING_BOX_CONFIG = {
 		interval: '30m'
 	},
 	inbounds: [
-		{ type: 'mixed', tag: 'mixed-in', listen: '0.0.0.0', listen_port: 2080 },
-		{ type: 'tun', tag: 'tun-in', address: '172.19.0.1/30', auto_route: true, strict_route: true, stack: 'mixed' }
+		{
+			tag: "tun-in",
+			type: "tun",
+			address: [
+				"172.19.0.0/30"
+			],
+			mtu: 9000,
+			auto_route: true,
+			strict_route: true,
+			stack: "system",
+			platform: {
+				http_proxy: {
+					enabled: true,
+					server: "127.0.0.1",
+					server_port: 2080
+				}
+			}
+		},
+		{
+			tag: "mixed-in",
+			type: "mixed",
+			listen: "127.0.0.1",
+			listen_port: 2080
+		}
 	],
 	outbounds: [
 		{ type: 'block', tag: 'REJECT' },
@@ -120,8 +142,30 @@ export const SING_BOX_CONFIG_V1_11 = {
 		interval: '30m'
 	},
 	inbounds: [
-		{ type: 'mixed', tag: 'mixed-in', listen: '0.0.0.0', listen_port: 2080 },
-		{ type: 'tun', tag: 'tun-in', address: '172.19.0.1/30', auto_route: true, strict_route: true, stack: 'mixed' }
+		{
+			tag: "tun-in",
+			type: "tun",
+			address: [
+				"172.19.0.0/30"
+			],
+			mtu: 9000,
+			auto_route: true,
+			strict_route: true,
+			stack: "system",
+			platform: {
+				http_proxy: {
+					enabled: true,
+					server: "127.0.0.1",
+					server_port: 2080
+				}
+			}
+		},
+		{
+			tag: "mixed-in",
+			type: "mixed",
+			listen: "127.0.0.1",
+			listen_port: 2080
+		}
 	],
 	outbounds: [
 		{ type: 'block', tag: 'REJECT' },

--- a/src/config/singboxConfig.js
+++ b/src/config/singboxConfig.js
@@ -23,7 +23,7 @@ export const SING_BOX_CONFIG = {
 				server: "dns_direct"
 			},
 			{
-				rule_set: "geosite-cn",
+				rule_set: "cn",
 				server: "dns_direct"
 			},
 			{
@@ -35,7 +35,7 @@ export const SING_BOX_CONFIG = {
 				server: "dns_proxy"
 			},
 			{
-				rule_set: "geosite-geolocation-!cn",
+				rule_set: "geolocation-!cn",
 				server: "dns_proxy"
 			}
 		],
@@ -58,10 +58,10 @@ export const SING_BOX_CONFIG = {
 	route: {
 		"rule_set": [
 			{
-				"tag": "geosite-geolocation-!cn",
+				"tag": "geolocation-!cn",
 				"type": "local",
 				"format": "binary",
-				"path": "geosite-geolocation-!cn.srs"
+				"path": "geolocation-!cn.srs"
 			}
 		],
 		rules: []
@@ -93,7 +93,7 @@ export const SING_BOX_CONFIG_V1_11 = {
 				server: "dns_direct"
 			},
 			{
-				rule_set: "geosite-cn",
+				rule_set: "cn",
 				server: "dns_direct"
 			},
 			{
@@ -105,7 +105,7 @@ export const SING_BOX_CONFIG_V1_11 = {
 				server: "dns_proxy"
 			},
 			{
-				rule_set: "geosite-geolocation-!cn",
+				rule_set: "geolocation-!cn",
 				server: "dns_proxy"
 			}
 		],

--- a/src/config/singboxConfig.js
+++ b/src/config/singboxConfig.js
@@ -7,39 +7,40 @@ export const SING_BOX_CONFIG = {
 	dns: {
 		servers: [
 			{
-				tag: "dns_proxy",
+				tag: "proxyDns",
 				address: "tls://8.8.8.8",
-				detour: "🚀 节点选择"
+				detour: "Proxy"
 			},
 			{
-				tag: "dns_direct",
-				address: "https://dns.alidns.com/dns-query",
-				detour: "DIRECT"
+				tag: "localDns",
+				address: "https://223.5.5.5/dns-query",
+				detour: "direct"
 			}
 		],
 		rules: [
 			{
 				outbound: "any",
-				server: "dns_direct"
+				server: "localDns"
 			},
 			{
-				rule_set: "cn",
-				server: "dns_direct"
+				rule_set: "geosite-cn",
+				server: "localDns"
 			},
 			{
 				clash_mode: "direct",
-				server: "dns_direct"
+				server: "localDns"
 			},
 			{
 				clash_mode: "global",
-				server: "dns_proxy"
+				server: "proxyDns"
 			},
 			{
-				rule_set: "geolocation-!cn",
-				server: "dns_proxy"
+				rule_set: "geosite-geolocation-!cn",
+				server: "proxyDns"
 			}
 		],
-		final: "dns_direct"
+		final: "localDns",
+		strategy: "ipv4_only"
 	},
 	ntp: {
 		enabled: true,
@@ -58,10 +59,10 @@ export const SING_BOX_CONFIG = {
 	route: {
 		"rule_set": [
 			{
-				"tag": "geolocation-!cn",
+				"tag": "geosite-geolocation-!cn",
 				"type": "local",
 				"format": "binary",
-				"path": "geolocation-!cn.srs"
+				"path": "geosite-geolocation-!cn.srs"
 			}
 		],
 		rules: []
@@ -77,39 +78,40 @@ export const SING_BOX_CONFIG_V1_11 = {
 	dns: {
 		servers: [
 			{
-				tag: "dns_proxy",
+				tag: "proxyDns",
 				address: "tls://8.8.8.8",
-				detour: "🚀 节点选择"
+				detour: "Proxy"
 			},
 			{
-				tag: "dns_direct",
-				address: "https://dns.alidns.com/dns-query",
-				detour: "DIRECT"
+				tag: "localDns",
+				address: "https://223.5.5.5/dns-query",
+				detour: "direct"
 			}
 		],
 		rules: [
 			{
 				outbound: "any",
-				server: "dns_direct"
+				server: "localDns"
 			},
 			{
-				rule_set: "cn",
-				server: "dns_direct"
+				rule_set: "geosite-cn",
+				server: "localDns"
 			},
 			{
 				clash_mode: "direct",
-				server: "dns_direct"
+				server: "localDns"
 			},
 			{
 				clash_mode: "global",
-				server: "dns_proxy"
+				server: "proxyDns"
 			},
 			{
-				rule_set: "geolocation-!cn",
-				server: "dns_proxy"
+				rule_set: "geosite-geolocation-!cn",
+				server: "proxyDns"
 			}
 		],
-		final: "dns_direct"
+		final: "localDns",
+		strategy: "ipv4_only"
 	},
 	ntp: {
 		enabled: true,

--- a/src/config/singboxConfig.js
+++ b/src/config/singboxConfig.js
@@ -67,7 +67,7 @@ export const SING_BOX_CONFIG = {
 	},
 	inbounds: [
 		{ type: 'mixed', tag: 'mixed-in', listen: '0.0.0.0', listen_port: 2080 },
-		{ type: 'tun', tag: 'tun-in', address: '172.19.0.1/30', auto_route: true, strict_route: true, stack: 'mixed', sniff: true }
+		{ type: 'tun', tag: 'tun-in', address: '172.19.0.1/30', auto_route: true, strict_route: true, stack: 'mixed' }
 	],
 	outbounds: [
 		{ type: 'block', tag: 'REJECT' },
@@ -159,7 +159,7 @@ export const SING_BOX_CONFIG_V1_11 = {
 	},
 	inbounds: [
 		{ type: 'mixed', tag: 'mixed-in', listen: '0.0.0.0', listen_port: 2080 },
-		{ type: 'tun', tag: 'tun-in', address: '172.19.0.1/30', auto_route: true, strict_route: true, stack: 'mixed', sniff: true }
+		{ type: 'tun', tag: 'tun-in', address: '172.19.0.1/30', auto_route: true, strict_route: true, stack: 'mixed' }
 	],
 	outbounds: [
 		{ type: 'block', tag: 'REJECT' },

--- a/src/config/singboxConfig.js
+++ b/src/config/singboxConfig.js
@@ -39,8 +39,7 @@ export const SING_BOX_CONFIG = {
 				server: "dns_proxy"
 			}
 		],
-		final: "dns_direct",
-		strategy: "ipv4_only"
+		final: "dns_direct"
 	},
 	ntp: {
 		enabled: true,
@@ -57,7 +56,6 @@ export const SING_BOX_CONFIG = {
 		{ type: "direct", tag: 'DIRECT' }
 	],
 	route: {
-		default_domain_resolver: "dns_direct",
 		"rule_set": [
 			{
 				"tag": "geosite-geolocation-!cn",
@@ -111,8 +109,7 @@ export const SING_BOX_CONFIG_V1_11 = {
 				server: "dns_proxy"
 			}
 		],
-		final: "dns_direct",
-		strategy: "ipv4_only"
+		final: "dns_direct"
 	},
 	ntp: {
 		enabled: true,

--- a/src/config/singboxConfig.js
+++ b/src/config/singboxConfig.js
@@ -7,57 +7,40 @@ export const SING_BOX_CONFIG = {
 	dns: {
 		servers: [
 			{
-				type: "tcp",
 				tag: "dns_proxy",
-				server: "1.1.1.1",
-				detour: "🚀 节点选择",
-				domain_resolver: "dns_resolver"
+				address: "tls://8.8.8.8",
+				detour: "🚀 节点选择"
 			},
 			{
-				type: "https",
 				tag: "dns_direct",
-				server: "dns.alidns.com",
-				domain_resolver: "dns_resolver"
-			},
-			{
-				type: "udp",
-				tag: "dns_resolver",
-				server: "223.5.5.5"
-			},
-			{
-				type: "fakeip",
-				tag: "dns_fakeip",
-				inet4_range: "198.18.0.0/15",
-				inet6_range: "fc00::/18"
+				address: "https://dns.alidns.com/dns-query",
+				detour: "DIRECT"
 			}
 		],
 		rules: [
 			{
-				rule_set: "geolocation-!cn",
-				query_type: [
-					"A",
-					"AAAA"
-				],
-				server: "dns_fakeip"
+				outbound: "any",
+				server: "dns_direct"
 			},
 			{
-				rule_set: "geolocation-!cn",
-				query_type: "CNAME",
+				rule_set: "geosite-cn",
+				server: "dns_direct"
+			},
+			{
+				clash_mode: "direct",
+				server: "dns_direct"
+			},
+			{
+				clash_mode: "global",
 				server: "dns_proxy"
 			},
 			{
-				query_type: [
-					"A",
-					"AAAA",
-					"CNAME"
-				],
-				invert: true,
-				action: "predefined",
-				rcode: "REFUSED"
+				rule_set: "geosite-geolocation-!cn",
+				server: "dns_proxy"
 			}
 		],
 		final: "dns_direct",
-		independent_cache: true
+		strategy: "ipv4_only"
 	},
 	ntp: {
 		enabled: true,
@@ -74,7 +57,7 @@ export const SING_BOX_CONFIG = {
 		{ type: "direct", tag: 'DIRECT' }
 	],
 	route: {
-		default_domain_resolver: "dns_resolver",
+		default_domain_resolver: "dns_direct",
 		"rule_set": [
 			{
 				"tag": "geosite-geolocation-!cn",
@@ -87,8 +70,7 @@ export const SING_BOX_CONFIG = {
 	},
 	experimental: {
 		cache_file: {
-			enabled: true,
-			store_fakeip: true
+			enabled: true
 		}
 	}
 };
@@ -98,58 +80,39 @@ export const SING_BOX_CONFIG_V1_11 = {
 		servers: [
 			{
 				tag: "dns_proxy",
-				address: "tls://1.1.1.1",
+				address: "tls://8.8.8.8",
 				detour: "🚀 节点选择"
 			},
 			{
 				tag: "dns_direct",
 				address: "https://dns.alidns.com/dns-query",
-				detour: "DIRECT",
-				address_resolver: "dns_resolver"
-			},
-			{
-				tag: "dns_resolver",
-				address: "223.5.5.5",
 				detour: "DIRECT"
-			},
-			{
-				tag: "dns_fakeip",
-				address: "fakeip"
 			}
 		],
 		rules: [
 			{
-				rule_set: "geolocation-!cn",
-				query_type: [
-					"A",
-					"AAAA"
-				],
-				server: "dns_fakeip"
+				outbound: "any",
+				server: "dns_direct"
 			},
 			{
-				rule_set: "geolocation-!cn",
-				query_type: "CNAME",
+				rule_set: "geosite-cn",
+				server: "dns_direct"
+			},
+			{
+				clash_mode: "direct",
+				server: "dns_direct"
+			},
+			{
+				clash_mode: "global",
 				server: "dns_proxy"
 			},
 			{
-				query_type: [
-					"A",
-					"AAAA",
-					"CNAME"
-				],
-				invert: true,
-				server: "dns_direct",
-				disable_cache: true
+				rule_set: "geosite-geolocation-!cn",
+				server: "dns_proxy"
 			}
 		],
 		final: "dns_direct",
-		strategy: "prefer_ipv4",
-		independent_cache: true,
-		fakeip: {
-			enabled: true,
-			inet4_range: "198.18.0.0/15",
-			inet6_range: "fc00::/18"
-		}
+		strategy: "ipv4_only"
 	},
 	ntp: {
 		enabled: true,
@@ -171,8 +134,7 @@ export const SING_BOX_CONFIG_V1_11 = {
 	},
 	experimental: {
 		cache_file: {
-			enabled: true,
-			store_fakeip: true
+			enabled: true
 		}
 	}
 };


### PR DESCRIPTION
fix: remove legacy sniff field from tun inbound for sing-box 1.13.0 compatibility