### PR TITLE
fix: add subscription-userinfo header to /singbox endpoint

### DIFF
--- a/src/app/createApp.jsx
+++ b/src/app/createApp.jsx
@@ -114,6 +114,10 @@ export function createApp(bindings = {}) {
                 includeAutoSelect
             );
             await builder.build();
+            const userinfo = builder.getSubscriptionUserinfo();
+            if (userinfo) {
+                c.header('subscription-userinfo', userinfo);
+            }
             return c.json(builder.config);
         } catch (error) {
             return handleError(c, error, runtime.logger);


### PR DESCRIPTION
## Summary
- Add subscription-userinfo header forwarding to /singbox endpoint
- Follows up on PR #354 which added this for /clash and /surge

## Test plan
- [ ] /singbox endpoint returns subscription-userinfo header when available
- [ ] All existing tests pass