### PR TITLE
fix: prevent custom rules from acting as global when country grouping is enabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sublink-worker",
-  "version": "2.3.0",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sublink-worker",
-      "version": "2.3.0",
+      "version": "2.3.2",
       "dependencies": {
         "esbuild-register": "^3.6.0",
         "hono": "^4.10.7",

--- a/src/builders/ClashConfigBuilder.js
+++ b/src/builders/ClashConfigBuilder.js
@@ -413,7 +413,16 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
             this.customRules.forEach(rule => {
                 const name = this.t(`outboundNames.${rule.name}`);
                 if (!this.hasProxyGroup(name)) {
-                    const proxies = this.buildSelectGroupMembers(proxyList);
+                    // Custom rules should not include country groups as direct proxies
+                    // to prevent them from acting as global proxies.
+                    // Custom rules should route through: Node Select -> Country Groups
+                    const proxies = [
+                        this.t('outboundNames.Node Select'),
+                        ...(this.includeAutoSelect ? [this.t('outboundNames.Auto Select')] : []),
+                        ...(this.manualGroupName ? [this.manualGroupName] : []),
+                        'DIRECT',
+                        'REJECT'
+                    ];
                     const group = {
                         type: "select",
                         name,

--- a/src/builders/SingboxConfigBuilder.js
+++ b/src/builders/SingboxConfigBuilder.js
@@ -222,7 +222,16 @@ export class SingboxConfigBuilder extends BaseConfigBuilder {
     addCustomRuleGroups(proxyList) {
         if (Array.isArray(this.customRules)) {
             this.customRules.forEach(rule => {
-                const selectorMembers = this.buildSelectorMembers(proxyList);
+                // Custom rules should not include country groups as direct outbounds
+                // to prevent them from acting as global proxies.
+                // Custom rules should route through: Node Select -> Country Groups
+                const selectorMembers = [
+                    this.t('outboundNames.Node Select'),
+                    ...(this.includeAutoSelect ? [this.t('outboundNames.Auto Select')] : []),
+                    ...(this.manualGroupName ? [this.manualGroupName] : []),
+                    'DIRECT',
+                    'REJECT'
+                ];
                 if (this.hasOutboundTag(rule.name)) return;
                 this.config.outbounds.push({
                     type: "selector",

--- a/src/builders/SurgeConfigBuilder.js
+++ b/src/builders/SurgeConfigBuilder.js
@@ -296,8 +296,17 @@ export class SurgeConfigBuilder extends BaseConfigBuilder {
     addCustomRuleGroups(proxyList) {
         if (Array.isArray(this.customRules)) {
             this.customRules.forEach(rule => {
-                const options = this.buildAggregatedOptions(proxyList);
                 if (this.hasProxyGroup(rule.name)) return;
+                // Custom rules should not include country groups as direct options
+                // to prevent them from acting as global proxies.
+                // Custom rules should route through: Node Select -> Country Groups
+                const options = [
+                    this.t('outboundNames.Node Select'),
+                    ...(this.includeAutoSelect ? [this.t('outboundNames.Auto Select')] : []),
+                    ...(this.manualGroupName ? [this.manualGroupName] : []),
+                    'DIRECT',
+                    'REJECT'
+                ];
                 this.config['proxy-groups'].push(
                     this.createProxyGroup(rule.name, 'select', options)
                 );

--- a/test/issue-256-custom-rule-global.test.js
+++ b/test/issue-256-custom-rule-global.test.js
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import { SingboxConfigBuilder } from '../src/builders/SingboxConfigBuilder.js';
+import { ClashConfigBuilder } from '../src/builders/ClashConfigBuilder.js';
+import { SurgeConfigBuilder } from '../src/builders/SurgeConfigBuilder.js';
+
+/**
+ * Issue #256 Regression Test
+ * Custom rules should not include country groups as direct outbounds
+ * to prevent them from acting as global proxies.
+ */
+describe('Issue #256 - Custom rules should not bypass selector chain', () => {
+    const inputString = 'ss://YWVzLTI1Ni1nY206dGVzdA==@us1.example.com:8388#US-Node-1\n' +
+                       'ss://YWVzLTI1Ni1nY206dGVzdA==@uk1.example.com:8388#UK-Node-1';
+
+    const customRules = [
+        { name: 'Custom-Rule-1', site_rules: ['google'], ip_rules: [], domain_suffix: [], domain_keyword: [] },
+        { name: 'Custom-Rule-2', site_rules: ['github'], ip_rules: [], domain_suffix: [], domain_keyword: [] }
+    ];
+
+    // Expected translated names for zh-CN locale
+    const NODE_SELECT = '🚀 节点选择';
+    const AUTO_SELECT = '⚡ 自动选择';
+
+    describe('SingboxConfigBuilder', () => {
+        it('should not include country groups in custom rule outbounds when groupByCountry is enabled', async () => {
+            const builder = new SingboxConfigBuilder(
+                inputString,
+                'minimal',
+                customRules,
+                null,
+                'zh-CN',
+                '',
+                true, // groupByCountry = true
+                false,
+                null,
+                null,
+                '1.12',
+                true
+            );
+
+            await builder.build();
+
+            // Find custom rule outbounds
+            const customRule1 = builder.config.outbounds.find(o => o?.tag === 'Custom-Rule-1');
+            const customRule2 = builder.config.outbounds.find(o => o?.tag === 'Custom-Rule-2');
+
+            expect(customRule1).toBeDefined();
+            expect(customRule2).toBeDefined();
+
+            // Custom rules should contain Node Select, Auto Select, DIRECT, REJECT
+            // But should NOT contain country groups like "🇺🇸 United States"
+            expect(customRule1.outbounds).toContain(NODE_SELECT);
+            expect(customRule1.outbounds).toContain(AUTO_SELECT);
+            expect(customRule1.outbounds).toContain('DIRECT');
+            expect(customRule1.outbounds).toContain('REJECT');
+
+            // Should NOT contain country groups
+            const hasCountryGroup = customRule1.outbounds.some(tag =>
+                tag.includes('🇺🇸') || tag.includes('🇬🇧') || tag.includes('United States') || tag.includes('United Kingdom')
+            );
+            expect(hasCountryGroup).toBe(false);
+
+            // Verify the same for customRule2
+            expect(customRule2.outbounds).toContain(NODE_SELECT);
+            const hasCountryGroup2 = customRule2.outbounds.some(tag =>
+                tag.includes('🇺🇸') || tag.includes('🇬🇧') || tag.includes('United States') || tag.includes('United Kingdom')
+            );
+            expect(hasCountryGroup2).toBe(false);
+        });
+
+        it('should still include country groups in Node Select when groupByCountry is enabled', async () => {
+            const builder = new SingboxConfigBuilder(
+                inputString,
+                'minimal',
+                customRules,
+                null,
+                'zh-CN',
+                '',
+                true, // groupByCountry = true
+                false,
+                null,
+                null,
+                '1.12',
+                true
+            );
+
+            await builder.build();
+
+            // Node Select should contain country groups
+            const nodeSelect = builder.config.outbounds.find(o => o?.tag === NODE_SELECT);
+            expect(nodeSelect).toBeDefined();
+
+            // Node Select should contain country groups as options
+            const hasCountryGroup = nodeSelect.outbounds.some(tag =>
+                tag.includes('🇺🇸') || tag.includes('🇬🇧') || tag.includes('United States') || tag.includes('United Kingdom')
+            );
+            expect(hasCountryGroup).toBe(true);
+        });
+    });
+
+    describe('ClashConfigBuilder', () => {
+        it('should not include country groups in custom rule proxies when groupByCountry is enabled', async () => {
+            const builder = new ClashConfigBuilder(
+                inputString,
+                'minimal',
+                customRules,
+                null,
+                'zh-CN',
+                '',
+                true, // groupByCountry = true
+                false,
+                null,
+                null,
+                true
+            );
+
+            await builder.build();
+
+            // Find custom rule proxy groups
+            const customRule1 = builder.config['proxy-groups'].find(g => g?.name === 'Custom-Rule-1');
+            const customRule2 = builder.config['proxy-groups'].find(g => g?.name === 'Custom-Rule-2');
+
+            expect(customRule1).toBeDefined();
+            expect(customRule2).toBeDefined();
+
+            // Custom rules should contain Node Select, Auto Select, DIRECT, REJECT
+            expect(customRule1.proxies).toContain(NODE_SELECT);
+            expect(customRule1.proxies).toContain(AUTO_SELECT);
+            expect(customRule1.proxies).toContain('DIRECT');
+            expect(customRule1.proxies).toContain('REJECT');
+
+            // Should NOT contain country groups
+            const hasCountryGroup = customRule1.proxies.some(tag =>
+                tag.includes('🇺🇸') || tag.includes('🇬🇧') || tag.includes('United States') || tag.includes('United Kingdom')
+            );
+            expect(hasCountryGroup).toBe(false);
+        });
+
+        it('should still include country groups in Node Select when groupByCountry is enabled', async () => {
+            const builder = new ClashConfigBuilder(
+                inputString,
+                'minimal',
+                customRules,
+                null,
+                'zh-CN',
+                '',
+                true, // groupByCountry = true
+                false,
+                null,
+                null,
+                true
+            );
+
+            await builder.build();
+
+            // Node Select should contain country groups
+            const nodeSelect = builder.config['proxy-groups'].find(g => g?.name === NODE_SELECT);
+            expect(nodeSelect).toBeDefined();
+
+            // Node Select should contain country groups as options
+            const hasCountryGroup = nodeSelect.proxies.some(tag =>
+                tag.includes('🇺🇸') || tag.includes('🇬🇧') || tag.includes('United States') || tag.includes('United Kingdom')
+            );
+            expect(hasCountryGroup).toBe(true);
+        });
+    });
+
+    describe('SurgeConfigBuilder', () => {
+        it('should not include country groups in custom rule options when groupByCountry is enabled', async () => {
+            const builder = new SurgeConfigBuilder(
+                inputString,
+                'minimal',
+                customRules,
+                null,
+                'zh-CN',
+                '',
+                true, // groupByCountry = true
+                true
+            );
+
+            await builder.build();
+
+            // Find custom rule proxy groups
+            const customRule1 = builder.config['proxy-groups'].find(g => {
+                const name = typeof g === 'string' ? g.split('=')[0].trim() : g?.name;
+                return name === 'Custom-Rule-1';
+            });
+            const customRule2 = builder.config['proxy-groups'].find(g => {
+                const name = typeof g === 'string' ? g.split('=')[0].trim() : g?.name;
+                return name === 'Custom-Rule-2';
+            });
+
+            expect(customRule1).toBeDefined();
+            expect(customRule2).toBeDefined();
+
+            // Get the options from the group string
+            const groupString = typeof customRule1 === 'string' ? customRule1 : '';
+
+            // Should contain Node Select
+            expect(groupString).toContain(NODE_SELECT);
+
+            // Should NOT contain country groups
+            expect(groupString).not.toContain('🇺🇸');
+            expect(groupString).not.toContain('🇬🇧');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Fix custom rule groups including country groups as direct outbounds in Sing-Box, Clash, and Surge configs
- Custom rules now route through the selector hierarchy (Node Select -> Country Groups) instead of bypassing it
- Added regression tests to prevent this issue from recurring

## Root Cause
When `groupByCountry=true`, `buildSelectorMembers()` returns country groups as direct outbound options. Custom rules were using this function to build their outbound lists, which meant selecting a country group in a custom rule would route ALL matching traffic directly to that country's nodes, bypassing the main selector chain.

## Fix
Modified `addCustomRuleGroups()` in all three builders to manually construct the outbound list without country groups:
- Node Select (for routing through the main selector chain)
- Auto Select (optional)
- Manual Switch (if exists)
- DIRECT, REJECT

Country groups are still accessible through Node Select, maintaining the intended hierarchy.

## Test Plan
- [x] Custom rules with country grouping enabled no longer affect all traffic
- [x] All existing 174 tests pass
- [x] Added 5 new regression tests for issue #256

closes #256