### PR TITLE
fix: restore custom rule selector breadth

### DIFF
--- a/src/builders/ClashConfigBuilder.js
+++ b/src/builders/ClashConfigBuilder.js
@@ -3,7 +3,7 @@ import { CLASH_CONFIG, generateRules, generateClashRuleSets, getOutbounds, PREDE
 import { BaseConfigBuilder } from './BaseConfigBuilder.js';
 import { deepCopy, groupProxiesByCountry } from '../utils.js';
 import { addProxyWithDedup } from './helpers/proxyHelpers.js';
-import { buildSelectorMembers, buildNodeSelectMembers, uniqueNames } from './helpers/groupBuilder.js';
+import { buildSelectorMembers, buildNodeSelectMembers, buildCustomRuleSelectorMembers, uniqueNames } from './helpers/groupBuilder.js';
 import { emitClashRules, sanitizeClashProxyGroups } from './helpers/clashConfigUtils.js';
 import { normalizeGroupName, findGroupIndexByName } from './helpers/groupNameUtils.js';
 
@@ -413,16 +413,13 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
             this.customRules.forEach(rule => {
                 const name = this.t(`outboundNames.${rule.name}`);
                 if (!this.hasProxyGroup(name)) {
-                    // Custom rules should not include country groups as direct proxies
-                    // to prevent them from acting as global proxies.
-                    // Custom rules should route through: Node Select -> Country Groups
-                    const proxies = [
-                        this.t('outboundNames.Node Select'),
-                        ...(this.includeAutoSelect ? [this.t('outboundNames.Auto Select')] : []),
-                        ...(this.manualGroupName ? [this.manualGroupName] : []),
-                        'DIRECT',
-                        'REJECT'
-                    ];
+                    const proxies = buildCustomRuleSelectorMembers({
+                        proxyList,
+                        translator: this.t,
+                        groupByCountry: this.groupByCountry,
+                        manualGroupName: this.manualGroupName,
+                        includeAutoSelect: this.includeAutoSelect
+                    });
                     const group = {
                         type: "select",
                         name,

--- a/src/builders/SingboxConfigBuilder.js
+++ b/src/builders/SingboxConfigBuilder.js
@@ -3,7 +3,7 @@ import { SING_BOX_CONFIG, generateRuleSets, generateRules, getOutbounds, PREDEFI
 import { BaseConfigBuilder } from './BaseConfigBuilder.js';
 import { deepCopy, groupProxiesByCountry } from '../utils.js';
 import { addProxyWithDedup } from './helpers/proxyHelpers.js';
-import { buildSelectorMembers as buildSelectorMemberList, buildNodeSelectMembers, uniqueNames } from './helpers/groupBuilder.js';
+import { buildSelectorMembers as buildSelectorMemberList, buildNodeSelectMembers, uniqueNames, buildCustomRuleSelectorMembers } from './helpers/groupBuilder.js';
 import { normalizeGroupName } from './helpers/groupNameUtils.js';
 
 export class SingboxConfigBuilder extends BaseConfigBuilder {
@@ -230,16 +230,13 @@ export class SingboxConfigBuilder extends BaseConfigBuilder {
         if (Array.isArray(this.customRules)) {
             this.customRules.forEach(rule => {
                 const includeAutoSelect = this.includeAutoSelect && this.hasAutoSelectCandidates(proxyList);
-                // Custom rules should not include country groups as direct outbounds
-                // to prevent them from acting as global proxies.
-                // Custom rules should route through: Node Select -> Country Groups
-                const selectorMembers = [
-                    this.t('outboundNames.Node Select'),
-                    ...(includeAutoSelect ? [this.t('outboundNames.Auto Select')] : []),
-                    ...(this.manualGroupName ? [this.manualGroupName] : []),
-                    'DIRECT',
-                    'REJECT'
-                ];
+                const selectorMembers = buildCustomRuleSelectorMembers({
+                    proxyList,
+                    translator: this.t,
+                    groupByCountry: this.groupByCountry,
+                    manualGroupName: this.manualGroupName,
+                    includeAutoSelect
+                });
                 if (this.hasOutboundTag(rule.name)) return;
                 this.config.outbounds.push({
                     type: "selector",

--- a/src/builders/SurgeConfigBuilder.js
+++ b/src/builders/SurgeConfigBuilder.js
@@ -2,7 +2,7 @@ import { BaseConfigBuilder } from './BaseConfigBuilder.js';
 import { groupProxiesByCountry } from '../utils.js';
 import { SURGE_CONFIG, SURGE_SITE_RULE_SET_BASEURL, SURGE_IP_RULE_SET_BASEURL, generateRules, getOutbounds, PREDEFINED_RULE_SETS, DIRECT_DEFAULT_RULES } from '../config/index.js';
 import { addProxyWithDedup } from './helpers/proxyHelpers.js';
-import { buildSelectorMembers, buildNodeSelectMembers, uniqueNames } from './helpers/groupBuilder.js';
+import { buildSelectorMembers, buildNodeSelectMembers, uniqueNames, buildCustomRuleSelectorMembers } from './helpers/groupBuilder.js';
 
 export class SurgeConfigBuilder extends BaseConfigBuilder {
     constructor(inputString, selectedRules, customRules, baseConfig, lang, userAgent, groupByCountry, includeAutoSelect = true) {
@@ -297,16 +297,13 @@ export class SurgeConfigBuilder extends BaseConfigBuilder {
         if (Array.isArray(this.customRules)) {
             this.customRules.forEach(rule => {
                 if (this.hasProxyGroup(rule.name)) return;
-                // Custom rules should not include country groups as direct options
-                // to prevent them from acting as global proxies.
-                // Custom rules should route through: Node Select -> Country Groups
-                const options = [
-                    this.t('outboundNames.Node Select'),
-                    ...(this.includeAutoSelect ? [this.t('outboundNames.Auto Select')] : []),
-                    ...(this.manualGroupName ? [this.manualGroupName] : []),
-                    'DIRECT',
-                    'REJECT'
-                ];
+                const options = buildCustomRuleSelectorMembers({
+                    proxyList,
+                    translator: this.t,
+                    groupByCountry: this.groupByCountry,
+                    manualGroupName: this.manualGroupName,
+                    includeAutoSelect: this.includeAutoSelect
+                });
                 this.config['proxy-groups'].push(
                     this.createProxyGroup(rule.name, 'select', options)
                 );

--- a/src/builders/helpers/groupBuilder.js
+++ b/src/builders/helpers/groupBuilder.js
@@ -56,3 +56,21 @@ export function buildSelectorMembers({ proxyList = [], translator, groupByCountr
         ];
     return withDirectReject(base);
 }
+
+export function buildCustomRuleSelectorMembers({ proxyList = [], translator, groupByCountry = false, manualGroupName, includeAutoSelect = true }) {
+    if (!groupByCountry) {
+        return buildSelectorMembers({
+            proxyList,
+            translator,
+            groupByCountry,
+            manualGroupName,
+            includeAutoSelect
+        });
+    }
+
+    return withDirectReject([
+        translator('outboundNames.Node Select'),
+        ...(includeAutoSelect ? [translator('outboundNames.Auto Select')] : []),
+        ...(manualGroupName ? [manualGroupName] : [])
+    ]);
+}

--- a/test/issue-256-custom-rule-global.test.js
+++ b/test/issue-256-custom-rule-global.test.js
@@ -22,6 +22,34 @@ describe('Issue #256 - Custom rules should not bypass selector chain', () => {
     const AUTO_SELECT = '⚡ 自动选择';
 
     describe('SingboxConfigBuilder', () => {
+        it('should restore full proxy options for custom rules when groupByCountry is disabled', async () => {
+            const builder = new SingboxConfigBuilder(
+                inputString,
+                'minimal',
+                customRules,
+                null,
+                'zh-CN',
+                '',
+                false,
+                false,
+                null,
+                null,
+                '1.12',
+                true
+            );
+
+            await builder.build();
+
+            const customRule1 = builder.config.outbounds.find(o => o?.tag === 'Custom-Rule-1');
+            expect(customRule1).toBeDefined();
+            expect(customRule1.outbounds).toContain(NODE_SELECT);
+            expect(customRule1.outbounds).toContain('US-Node-1');
+            expect(customRule1.outbounds).toContain('UK-Node-1');
+            expect(customRule1.outbounds).toContain('DIRECT');
+            expect(customRule1.outbounds).toContain('REJECT');
+            expect(customRule1.outbounds).not.toContain(AUTO_SELECT);
+        });
+
         it('should not include country groups in custom rule outbounds when groupByCountry is enabled', async () => {
             const builder = new SingboxConfigBuilder(
                 inputString,
@@ -99,6 +127,33 @@ describe('Issue #256 - Custom rules should not bypass selector chain', () => {
     });
 
     describe('ClashConfigBuilder', () => {
+        it('should restore full proxy options for custom rules when groupByCountry is disabled', async () => {
+            const builder = new ClashConfigBuilder(
+                inputString,
+                'minimal',
+                customRules,
+                null,
+                'zh-CN',
+                '',
+                false,
+                false,
+                null,
+                null,
+                true
+            );
+
+            await builder.build();
+
+            const customRule1 = builder.config['proxy-groups'].find(g => g?.name === 'Custom-Rule-1');
+            expect(customRule1).toBeDefined();
+            expect(customRule1.proxies).toContain(NODE_SELECT);
+            expect(customRule1.proxies).toContain('US-Node-1');
+            expect(customRule1.proxies).toContain('UK-Node-1');
+            expect(customRule1.proxies).toContain('DIRECT');
+            expect(customRule1.proxies).toContain('REJECT');
+            expect(customRule1.proxies).not.toContain(AUTO_SELECT);
+        });
+
         it('should not include country groups in custom rule proxies when groupByCountry is enabled', async () => {
             const builder = new ClashConfigBuilder(
                 inputString,
@@ -166,6 +221,35 @@ describe('Issue #256 - Custom rules should not bypass selector chain', () => {
     });
 
     describe('SurgeConfigBuilder', () => {
+        it('should restore full proxy options for custom rules when groupByCountry is disabled', async () => {
+            const builder = new SurgeConfigBuilder(
+                inputString,
+                'minimal',
+                customRules,
+                null,
+                'zh-CN',
+                '',
+                false,
+                true
+            );
+
+            await builder.build();
+
+            const customRule1 = builder.config['proxy-groups'].find(g => {
+                const name = typeof g === 'string' ? g.split('=')[0].trim() : g?.name;
+                return name === 'Custom-Rule-1';
+            });
+            expect(customRule1).toBeDefined();
+
+            const groupString = typeof customRule1 === 'string' ? customRule1 : '';
+            expect(groupString).toContain(NODE_SELECT);
+            expect(groupString).toContain('US-Node-1');
+            expect(groupString).toContain('UK-Node-1');
+            expect(groupString).toContain('DIRECT');
+            expect(groupString).toContain('REJECT');
+            expect(groupString).not.toContain(AUTO_SELECT);
+        });
+
         it('should not include country groups in custom rule options when groupByCountry is enabled', async () => {
             const builder = new SurgeConfigBuilder(
                 inputString,


### PR DESCRIPTION
https://github.com/7Sageer/sublink-worker/issues/371

解决这个问题