### PR TITLE
fix: restore custom rule proxy choices

### DIFF
--- a/src/builders/ClashConfigBuilder.js
+++ b/src/builders/ClashConfigBuilder.js
@@ -3,7 +3,7 @@ import { CLASH_CONFIG, generateRules, generateClashRuleSets, getOutbounds, PREDE
 import { BaseConfigBuilder } from './BaseConfigBuilder.js';
 import { deepCopy, groupProxiesByCountry } from '../utils.js';
 import { addProxyWithDedup } from './helpers/proxyHelpers.js';
-import { buildSelectorMembers, buildNodeSelectMembers, uniqueNames } from './helpers/groupBuilder.js';
+import { buildSelectorMembers, buildNodeSelectMembers, buildCustomRuleMembers, uniqueNames } from './helpers/groupBuilder.js';
 import { emitClashRules, sanitizeClashProxyGroups } from './helpers/clashConfigUtils.js';
 import { normalizeGroupName, findGroupIndexByName } from './helpers/groupNameUtils.js';
 
@@ -413,16 +413,12 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
             this.customRules.forEach(rule => {
                 const name = this.t(`outboundNames.${rule.name}`);
                 if (!this.hasProxyGroup(name)) {
-                    // Custom rules should not include country groups as direct proxies
-                    // to prevent them from acting as global proxies.
-                    // Custom rules should route through: Node Select -> Country Groups
-                    const proxies = [
-                        this.t('outboundNames.Node Select'),
-                        ...(this.includeAutoSelect ? [this.t('outboundNames.Auto Select')] : []),
-                        ...(this.manualGroupName ? [this.manualGroupName] : []),
-                        'DIRECT',
-                        'REJECT'
-                    ];
+                    const proxies = buildCustomRuleMembers({
+                        proxyList,
+                        translator: this.t,
+                        manualGroupName: this.manualGroupName,
+                        includeAutoSelect: this.includeAutoSelect
+                    });
                     const group = {
                         type: "select",
                         name,

--- a/src/builders/SingboxConfigBuilder.js
+++ b/src/builders/SingboxConfigBuilder.js
@@ -3,7 +3,7 @@ import { SING_BOX_CONFIG, generateRuleSets, generateRules, getOutbounds, PREDEFI
 import { BaseConfigBuilder } from './BaseConfigBuilder.js';
 import { deepCopy, groupProxiesByCountry } from '../utils.js';
 import { addProxyWithDedup } from './helpers/proxyHelpers.js';
-import { buildSelectorMembers as buildSelectorMemberList, buildNodeSelectMembers, uniqueNames } from './helpers/groupBuilder.js';
+import { buildSelectorMembers as buildSelectorMemberList, buildNodeSelectMembers, buildCustomRuleMembers, uniqueNames } from './helpers/groupBuilder.js';
 import { normalizeGroupName } from './helpers/groupNameUtils.js';
 
 export class SingboxConfigBuilder extends BaseConfigBuilder {
@@ -230,16 +230,12 @@ export class SingboxConfigBuilder extends BaseConfigBuilder {
         if (Array.isArray(this.customRules)) {
             this.customRules.forEach(rule => {
                 const includeAutoSelect = this.includeAutoSelect && this.hasAutoSelectCandidates(proxyList);
-                // Custom rules should not include country groups as direct outbounds
-                // to prevent them from acting as global proxies.
-                // Custom rules should route through: Node Select -> Country Groups
-                const selectorMembers = [
-                    this.t('outboundNames.Node Select'),
-                    ...(includeAutoSelect ? [this.t('outboundNames.Auto Select')] : []),
-                    ...(this.manualGroupName ? [this.manualGroupName] : []),
-                    'DIRECT',
-                    'REJECT'
-                ];
+                const selectorMembers = buildCustomRuleMembers({
+                    proxyList,
+                    translator: this.t,
+                    manualGroupName: this.manualGroupName,
+                    includeAutoSelect
+                });
                 if (this.hasOutboundTag(rule.name)) return;
                 this.config.outbounds.push({
                     type: "selector",

--- a/src/builders/SurgeConfigBuilder.js
+++ b/src/builders/SurgeConfigBuilder.js
@@ -2,7 +2,7 @@ import { BaseConfigBuilder } from './BaseConfigBuilder.js';
 import { groupProxiesByCountry } from '../utils.js';
 import { SURGE_CONFIG, SURGE_SITE_RULE_SET_BASEURL, SURGE_IP_RULE_SET_BASEURL, generateRules, getOutbounds, PREDEFINED_RULE_SETS, DIRECT_DEFAULT_RULES } from '../config/index.js';
 import { addProxyWithDedup } from './helpers/proxyHelpers.js';
-import { buildSelectorMembers, buildNodeSelectMembers, uniqueNames } from './helpers/groupBuilder.js';
+import { buildSelectorMembers, buildNodeSelectMembers, buildCustomRuleMembers, uniqueNames } from './helpers/groupBuilder.js';
 
 export class SurgeConfigBuilder extends BaseConfigBuilder {
     constructor(inputString, selectedRules, customRules, baseConfig, lang, userAgent, groupByCountry, includeAutoSelect = true) {
@@ -297,16 +297,12 @@ export class SurgeConfigBuilder extends BaseConfigBuilder {
         if (Array.isArray(this.customRules)) {
             this.customRules.forEach(rule => {
                 if (this.hasProxyGroup(rule.name)) return;
-                // Custom rules should not include country groups as direct options
-                // to prevent them from acting as global proxies.
-                // Custom rules should route through: Node Select -> Country Groups
-                const options = [
-                    this.t('outboundNames.Node Select'),
-                    ...(this.includeAutoSelect ? [this.t('outboundNames.Auto Select')] : []),
-                    ...(this.manualGroupName ? [this.manualGroupName] : []),
-                    'DIRECT',
-                    'REJECT'
-                ];
+                const options = buildCustomRuleMembers({
+                    proxyList,
+                    translator: this.t,
+                    manualGroupName: this.manualGroupName,
+                    includeAutoSelect: this.includeAutoSelect
+                });
                 this.config['proxy-groups'].push(
                     this.createProxyGroup(rule.name, 'select', options)
                 );

--- a/src/builders/helpers/groupBuilder.js
+++ b/src/builders/helpers/groupBuilder.js
@@ -56,3 +56,15 @@ export function buildSelectorMembers({ proxyList = [], translator, groupByCountr
         ];
     return withDirectReject(base);
 }
+
+export function buildCustomRuleMembers({ proxyList = [], translator, manualGroupName, includeAutoSelect = true }) {
+    if (!translator) {
+        throw new Error('buildCustomRuleMembers requires a translator function');
+    }
+    return withDirectReject([
+        translator('outboundNames.Node Select'),
+        ...(includeAutoSelect ? [translator('outboundNames.Auto Select')] : []),
+        ...(manualGroupName ? [manualGroupName] : []),
+        ...proxyList
+    ]);
+}

--- a/test/issue-371-custom-rule-options.test.js
+++ b/test/issue-371-custom-rule-options.test.js
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import { SingboxConfigBuilder } from '../src/builders/SingboxConfigBuilder.js';
+import { ClashConfigBuilder } from '../src/builders/ClashConfigBuilder.js';
+import { SurgeConfigBuilder } from '../src/builders/SurgeConfigBuilder.js';
+
+describe('Issue #371 - custom rule groups keep full proxy choices without country groups', () => {
+    const inputString = [
+        'ss://YWVzLTI1Ni1nY206dGVzdA==@us1.example.com:8388#US-Node-1',
+        'ss://YWVzLTI1Ni1nY206dGVzdA==@uk1.example.com:8388#UK-Node-1'
+    ].join('\n');
+
+    const customRules = [
+        { name: 'Custom-Rule', site_rules: ['google'], ip_rules: [], domain_suffix: [], domain_keyword: [] }
+    ];
+
+    const expectedCountryMembers = [
+        '🚀 节点选择',
+        '⚡ 自动选择',
+        '🖐️ 手动切换',
+        'US-Node-1',
+        'UK-Node-1',
+        'DIRECT',
+        'REJECT'
+    ];
+
+    const expectedFlatMembers = [
+        '🚀 节点选择',
+        '⚡ 自动选择',
+        'US-Node-1',
+        'UK-Node-1',
+        'DIRECT',
+        'REJECT'
+    ];
+
+    const expectCompleteOptionsWithoutCountries = (members, expectedMembers) => {
+        expect(members).toEqual(expectedMembers);
+        expect(members.some(member =>
+            member.includes('🇺🇸') || member.includes('🇬🇧') || member.includes('United States') || member.includes('United Kingdom')
+        )).toBe(false);
+    };
+
+    it('Singbox custom rule includes direct proxy choices when groupByCountry is enabled', async () => {
+        const builder = new SingboxConfigBuilder(
+            inputString,
+            'minimal',
+            customRules,
+            null,
+            'zh-CN',
+            '',
+            true,
+            false,
+            null,
+            null,
+            '1.12',
+            true
+        );
+
+        await builder.build();
+
+        const customRule = builder.config.outbounds.find(outbound => outbound?.tag === 'Custom-Rule');
+        expectCompleteOptionsWithoutCountries(customRule.outbounds, expectedCountryMembers);
+    });
+
+    it('Singbox custom rule includes direct proxy choices when groupByCountry is disabled', async () => {
+        const builder = new SingboxConfigBuilder(
+            inputString,
+            'minimal',
+            customRules,
+            null,
+            'zh-CN',
+            '',
+            false,
+            false,
+            null,
+            null,
+            '1.12',
+            true
+        );
+
+        await builder.build();
+
+        const customRule = builder.config.outbounds.find(outbound => outbound?.tag === 'Custom-Rule');
+        expectCompleteOptionsWithoutCountries(customRule.outbounds, expectedFlatMembers);
+    });
+
+    it('Clash custom rule includes direct proxy choices when groupByCountry is enabled', async () => {
+        const builder = new ClashConfigBuilder(
+            inputString,
+            'minimal',
+            customRules,
+            null,
+            'zh-CN',
+            '',
+            true,
+            false,
+            null,
+            null,
+            true
+        );
+
+        await builder.build();
+
+        const customRule = builder.config['proxy-groups'].find(group => group?.name === 'Custom-Rule');
+        expectCompleteOptionsWithoutCountries(customRule.proxies, expectedCountryMembers);
+    });
+
+    it('Clash custom rule includes direct proxy choices when groupByCountry is disabled', async () => {
+        const builder = new ClashConfigBuilder(
+            inputString,
+            'minimal',
+            customRules,
+            null,
+            'zh-CN',
+            '',
+            false,
+            false,
+            null,
+            null,
+            true
+        );
+
+        await builder.build();
+
+        const customRule = builder.config['proxy-groups'].find(group => group?.name === 'Custom-Rule');
+        expectCompleteOptionsWithoutCountries(customRule.proxies, expectedFlatMembers);
+    });
+
+    it('Surge custom rule includes direct proxy choices when groupByCountry is enabled', async () => {
+        const builder = new SurgeConfigBuilder(
+            inputString,
+            'minimal',
+            customRules,
+            null,
+            'zh-CN',
+            '',
+            true,
+            true
+        );
+
+        await builder.build();
+
+        const customRule = builder.config['proxy-groups'].find(group =>
+            typeof group === 'string' && group.startsWith('Custom-Rule = select')
+        );
+        expect(customRule).toBeDefined();
+
+        const members = customRule
+            .split(',')
+            .slice(1)
+            .map(member => member.trim());
+        expectCompleteOptionsWithoutCountries(members, expectedCountryMembers);
+    });
+
+    it('Surge custom rule includes direct proxy choices when groupByCountry is disabled', async () => {
+        const builder = new SurgeConfigBuilder(
+            inputString,
+            'minimal',
+            customRules,
+            null,
+            'zh-CN',
+            '',
+            false,
+            true
+        );
+
+        await builder.build();
+
+        const customRule = builder.config['proxy-groups'].find(group =>
+            typeof group === 'string' && group.startsWith('Custom-Rule = select')
+        );
+        expect(customRule).toBeDefined();
+
+        const members = customRule
+            .split(',')
+            .slice(1)
+            .map(member => member.trim());
+        expectCompleteOptionsWithoutCountries(members, expectedFlatMembers);
+    });
+});


### PR DESCRIPTION
## Summary
- restore direct proxy choices in custom rule selector groups for Singbox, Clash, and Surge
- keep country groups out of custom rule groups so the #256/#364 selector-chain fix does not regress
- add #371 regression coverage for all three builders with groupByCountry enabled and disabled

## Notes
- #372 restores only the non-country-grouping path; this fix covers the reported groupByCountry=true regression as well.
- The existing local .gitignore change is intentionally not included.

## Tests
- npx vitest run test/issue-256-custom-rule-global.test.js test/issue-366-empty-auto-select.test.js test/issue-370-empty-clash-output.test.js test/issue-371-custom-rule-options.test.js
- npx vitest run

Fixes #371