### PR TITLE
Fix stable auto provider names

### DIFF
--- a/src/builders/BaseConfigBuilder.js
+++ b/src/builders/BaseConfigBuilder.js
@@ -1,5 +1,5 @@
 import { ProxyParser } from '../parsers/index.js';
-import { deepCopy, tryDecodeSubscriptionLines, decodeBase64 } from '../utils.js';
+import { createStableProviderName, deepCopy, tryDecodeSubscriptionLines, decodeBase64 } from '../utils.js';
 import { createTranslator } from '../i18n/index.js';
 import { generateRules, getOutbounds, PREDEFINED_RULE_SETS } from '../config/index.js';
 
@@ -15,6 +15,7 @@ export class BaseConfigBuilder {
         this.groupByCountry = groupByCountry;
         this.includeAutoSelect = includeAutoSelect;
         this.providerUrls = [];  // URLs to use as providers (auto-sync)
+        this.autoProviderDescriptors = undefined;
         this.subscriptionUserinfo = undefined;
     }
 
@@ -183,6 +184,43 @@ export class BaseConfigBuilder {
      */
     isCompatibleProviderFormat(format) {
         return false;  // Default: no provider support
+    }
+
+    getAutoProviderDescriptors(reservedNames = []) {
+        if (this.autoProviderDescriptors) {
+            return this.autoProviderDescriptors;
+        }
+
+        const usedNames = new Set(reservedNames);
+        const providerNamesByUrl = new Map();
+        const descriptors = [];
+
+        for (const url of this.providerUrls) {
+            if (typeof url !== 'string' || url.trim() === '') {
+                throw new Error('Provider URL must be a non-empty string');
+            }
+
+            const normalizedUrl = url.trim();
+            if (providerNamesByUrl.has(normalizedUrl)) {
+                continue;
+            }
+
+            const baseName = createStableProviderName(normalizedUrl);
+            let name = baseName;
+            let suffix = 2;
+
+            while (usedNames.has(name)) {
+                name = `${baseName}_${suffix}`;
+                suffix += 1;
+            }
+
+            usedNames.add(name);
+            providerNamesByUrl.set(normalizedUrl, name);
+            descriptors.push({ name, url: normalizedUrl });
+        }
+
+        this.autoProviderDescriptors = descriptors;
+        return descriptors;
     }
 
     applyConfigOverrides(overrides) {

--- a/src/builders/ClashConfigBuilder.js
+++ b/src/builders/ClashConfigBuilder.js
@@ -77,8 +77,8 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
      */
     generateProxyProviders() {
         const providers = {};
-        this.providerUrls.forEach((url, index) => {
-            const name = `_auto_provider_${index + 1}`;
+        const existingProviders = this.getExistingProviderNames();
+        this.getAutoProviderDescriptors(existingProviders).forEach(({ name, url }) => {
             providers[name] = {
                 type: 'http',
                 url: url,
@@ -101,7 +101,13 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
      * @returns {string[]} - Array of provider names
      */
     getProviderNames() {
-        return this.providerUrls.map((_, index) => `_auto_provider_${index + 1}`);
+        return this.getAutoProviderDescriptors(this.getExistingProviderNames()).map(provider => provider.name);
+    }
+
+    getExistingProviderNames() {
+        return this.config?.['proxy-providers'] && typeof this.config['proxy-providers'] === 'object'
+            ? Object.keys(this.config['proxy-providers'])
+            : [];
     }
 
     /**
@@ -109,9 +115,7 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
      * @returns {string[]} - Array of provider names
      */
     getAllProviderNames() {
-        const existingProviders = this.config?.['proxy-providers'] && typeof this.config['proxy-providers'] === 'object'
-            ? Object.keys(this.config['proxy-providers'])
-            : [];
+        const existingProviders = this.getExistingProviderNames();
         const autoProviders = this.getProviderNames();
         return [...new Set([...existingProviders, ...autoProviders])];
     }

--- a/src/builders/SingboxConfigBuilder.js
+++ b/src/builders/SingboxConfigBuilder.js
@@ -44,11 +44,12 @@ export class SingboxConfigBuilder extends BaseConfigBuilder {
      * @returns {object[]} - Array of outbound provider objects
      */
     generateOutboundProviders() {
-        return this.providerUrls.map((url, index) => ({
-            tag: `_auto_provider_${index + 1}`,
+        const existingTags = this.getExistingProviderTags();
+        return this.getAutoProviderDescriptors(existingTags).map(({ name, url }) => ({
+            tag: name,
             type: 'http',
             download_url: url,
-            path: `./providers/_auto_provider_${index + 1}.json`,
+            path: `./providers/${name}.json`,
             download_interval: '24h',
             health_check: {
                 enabled: true,
@@ -63,7 +64,13 @@ export class SingboxConfigBuilder extends BaseConfigBuilder {
      * @returns {string[]} - Array of provider tags
      */
     getProviderTags() {
-        return this.providerUrls.map((_, index) => `_auto_provider_${index + 1}`);
+        return this.getAutoProviderDescriptors(this.getExistingProviderTags()).map(provider => provider.name);
+    }
+
+    getExistingProviderTags() {
+        return Array.isArray(this.config.outbound_providers)
+            ? this.config.outbound_providers.map(p => p?.tag).filter(Boolean)
+            : [];
     }
 
     /**
@@ -74,9 +81,7 @@ export class SingboxConfigBuilder extends BaseConfigBuilder {
         if (this.singboxVersion === '1.11') {
             return [];
         }
-        const existingTags = Array.isArray(this.config.outbound_providers)
-            ? this.config.outbound_providers.map(p => p?.tag).filter(Boolean)
-            : [];
+        const existingTags = this.getExistingProviderTags();
         const autoTags = this.getProviderTags();
         return [...new Set([...existingTags, ...autoTags])];
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,6 @@
 const PATH_LENGTH = 7;
+const FNV_32_OFFSET_BASIS = 0x811c9dc5;
+const FNV_32_PRIME = 0x01000193;
 
 // 自定义的字符串前缀检查函数
 export function checkStartsWith(str, prefix) {
@@ -209,6 +211,22 @@ export function groupProxiesByCountry(proxies, { getName } = {}) {
 
 	return grouped;
 }
+
+export function createStableProviderName(url) {
+	if (typeof url !== 'string' || url.trim() === '') {
+		throw new Error('Provider URL must be a non-empty string');
+	}
+
+	const normalizedUrl = url.trim();
+	let hash = FNV_32_OFFSET_BASIS;
+	for (let i = 0; i < normalizedUrl.length; i++) {
+		hash ^= normalizedUrl.charCodeAt(i);
+		hash = Math.imul(hash, FNV_32_PRIME);
+	}
+
+	return `_auto_provider_${(hash >>> 0).toString(36)}`;
+}
+
 export function deepCopy(obj) {
 	if (obj === null || typeof obj !== 'object') {
 		return obj;

--- a/test/issue-370-empty-clash-output.test.js
+++ b/test/issue-370-empty-clash-output.test.js
@@ -72,10 +72,12 @@ describe('Issues #370/#373/#277 - remote subscription decode and empty Clash out
         );
         const built = yaml.load(await builder.build());
 
-        expect(built['proxy-providers']?._auto_provider_1?.url).toBe('https://example.com/plain-clash.yaml');
+        const providerName = Object.keys(built['proxy-providers'] ?? {})[0];
+        expect(providerName).toMatch(/^_auto_provider_[a-z0-9]+$/);
+        expect(built['proxy-providers'][providerName]?.url).toBe('https://example.com/plain-clash.yaml');
 
         const autoSelect = built['proxy-groups'].find(group => group.name === '⚡ 自动选择');
-        expect(autoSelect.use).toEqual(['_auto_provider_1']);
+        expect(autoSelect.use).toEqual([providerName]);
         expectNoEmptyUrlTestGroup(built);
     });
 

--- a/test/proxy-providers.test.js
+++ b/test/proxy-providers.test.js
@@ -69,13 +69,15 @@ describe('Auto Proxy Providers Detection', () => {
             // Should have proxy-providers
             expect(config['proxy-providers']).toBeDefined();
             expect(Object.keys(config['proxy-providers'])).toHaveLength(1);
-            expect(config['proxy-providers']._auto_provider_1).toBeDefined();
-            expect(config['proxy-providers']._auto_provider_1.url).toBe('https://example.com/clash-sub?token=xxx');
-            expect(config['proxy-providers']._auto_provider_1.type).toBe('http');
+            const providerName = Object.keys(config['proxy-providers'])[0];
+            expect(providerName).toMatch(/^_auto_provider_[a-z0-9]+$/);
+            expect(config['proxy-providers'][providerName].url).toBe('https://example.com/clash-sub?token=xxx');
+            expect(config['proxy-providers'][providerName].type).toBe('http');
+            expect(config['proxy-providers'][providerName].path).toBe(`./proxy_providers/${providerName}.yaml`);
 
             // proxy-groups should have 'use' field
             const nodeSelect = config['proxy-groups'].find(g => g.name === '🚀 节点选择');
-            expect(nodeSelect.use).toContain('_auto_provider_1');
+            expect(nodeSelect.use).toContain(providerName);
         });
 
         it('should parse and convert Sing-Box URL (incompatible format)', async () => {
@@ -130,12 +132,15 @@ describe('Auto Proxy Providers Detection', () => {
             // Should have outbound_providers
             expect(config.outbound_providers).toBeDefined();
             expect(config.outbound_providers).toHaveLength(1);
-            expect(config.outbound_providers[0].download_url).toBe('https://example.com/singbox-sub?token=xxx');
-            expect(config.outbound_providers[0].type).toBe('http');
+            const provider = config.outbound_providers[0];
+            expect(provider.tag).toMatch(/^_auto_provider_[a-z0-9]+$/);
+            expect(provider.download_url).toBe('https://example.com/singbox-sub?token=xxx');
+            expect(provider.type).toBe('http');
+            expect(provider.path).toBe(`./providers/${provider.tag}.json`);
 
             // outbounds should have 'providers' field
             const nodeSelect = config.outbounds.find(o => o.tag === '🚀 节点选择');
-            expect(nodeSelect.providers).toContain('_auto_provider_1');
+            expect(nodeSelect.providers).toContain(provider.tag);
         });
 
         it('should parse and convert Clash URL (incompatible format)', async () => {
@@ -224,9 +229,108 @@ describe('Auto Proxy Providers Detection', () => {
 
             // Should have two proxy-providers
             expect(config['proxy-providers']).toBeDefined();
-            expect(Object.keys(config['proxy-providers'])).toHaveLength(2);
-            expect(config['proxy-providers']._auto_provider_1).toBeDefined();
-            expect(config['proxy-providers']._auto_provider_2).toBeDefined();
+            const providerNames = Object.keys(config['proxy-providers']);
+            expect(providerNames).toHaveLength(2);
+            expect(new Set(providerNames).size).toBe(2);
+            expect(providerNames.every(name => name.startsWith('_auto_provider_'))).toBe(true);
+
+            const nodeSelect = config['proxy-groups'].find(g => g.name === '🚀 节点选择');
+            expect(nodeSelect.use).toEqual(expect.arrayContaining(providerNames));
+        });
+
+        it('should generate distinct stable Clash provider paths across separate builds', async () => {
+            fetchSubscriptionWithFormat.mockImplementation((url) => Promise.resolve({
+                content: mockClashYaml,
+                format: 'clash',
+                url
+            }));
+
+            const firstBuilder = new ClashConfigBuilder(
+                'https://provider-a.example.com/sub?token=aaa',
+                [],
+                [],
+                null,
+                'zh-CN',
+                'test-agent'
+            );
+            const secondBuilder = new ClashConfigBuilder(
+                'https://provider-b.example.com/sub?token=bbb',
+                [],
+                [],
+                null,
+                'zh-CN',
+                'test-agent'
+            );
+
+            const firstConfig = yaml.load(await firstBuilder.build());
+            const secondConfig = yaml.load(await secondBuilder.build());
+            const firstProviderName = Object.keys(firstConfig['proxy-providers'])[0];
+            const secondProviderName = Object.keys(secondConfig['proxy-providers'])[0];
+            const firstProvider = firstConfig['proxy-providers'][firstProviderName];
+            const secondProvider = secondConfig['proxy-providers'][secondProviderName];
+
+            expect(firstProviderName).not.toBe(secondProviderName);
+            expect(firstProvider.path).not.toBe(secondProvider.path);
+            expect(firstProvider.path).toBe(`./proxy_providers/${firstProviderName}.yaml`);
+            expect(secondProvider.path).toBe(`./proxy_providers/${secondProviderName}.yaml`);
+        });
+
+        it('should keep Clash provider name stable for the same URL', async () => {
+            fetchSubscriptionWithFormat.mockImplementation((url) => Promise.resolve({
+                content: mockClashYaml,
+                format: 'clash',
+                url
+            }));
+
+            const buildProviderName = async () => {
+                const builder = new ClashConfigBuilder(
+                    'https://stable.example.com/sub?token=same',
+                    [],
+                    [],
+                    null,
+                    'zh-CN',
+                    'test-agent'
+                );
+                const config = yaml.load(await builder.build());
+                return Object.keys(config['proxy-providers'])[0];
+            };
+
+            await expect(buildProviderName()).resolves.toBe(await buildProviderName());
+        });
+
+        it('should generate distinct stable Sing-Box provider paths across separate builds', async () => {
+            fetchSubscriptionWithFormat.mockImplementation((url) => Promise.resolve({
+                content: mockSingboxJson,
+                format: 'singbox',
+                url
+            }));
+
+            const firstBuilder = new SingboxConfigBuilder(
+                'https://provider-a.example.com/singbox?token=aaa',
+                [],
+                [],
+                null,
+                'zh-CN',
+                'test-agent'
+            );
+            const secondBuilder = new SingboxConfigBuilder(
+                'https://provider-b.example.com/singbox?token=bbb',
+                [],
+                [],
+                null,
+                'zh-CN',
+                'test-agent'
+            );
+
+            const firstConfig = await firstBuilder.build();
+            const secondConfig = await secondBuilder.build();
+            const firstProvider = firstConfig.outbound_providers[0];
+            const secondProvider = secondConfig.outbound_providers[0];
+
+            expect(firstProvider.tag).not.toBe(secondProvider.tag);
+            expect(firstProvider.path).not.toBe(secondProvider.path);
+            expect(firstProvider.path).toBe(`./providers/${firstProvider.tag}.json`);
+            expect(secondProvider.path).toBe(`./providers/${secondProvider.tag}.json`);
         });
     });
 
@@ -261,11 +365,13 @@ describe('Auto Proxy Providers Detection', () => {
 
             expect(config['proxy-providers']).toBeDefined();
             expect(config['proxy-providers'].provider1?.url).toBe('https://user.example.com/sub');
-            expect(config['proxy-providers']._auto_provider_1?.url).toBe('https://auto.example.com/clash-sub');
+            const autoProviderName = Object.keys(config['proxy-providers'])
+                .find(name => name.startsWith('_auto_provider_'));
+            expect(config['proxy-providers'][autoProviderName]?.url).toBe('https://auto.example.com/clash-sub');
 
             const nodeSelect = config['proxy-groups'].find(g => g.name === '🚀 节点选择');
             expect(nodeSelect.use).toContain('provider1');
-            expect(nodeSelect.use).toContain('_auto_provider_1');
+            expect(nodeSelect.use).toContain(autoProviderName);
         });
 
         it('should merge user-defined Sing-Box outbound_providers with auto providers', async () => {
@@ -299,11 +405,13 @@ describe('Auto Proxy Providers Detection', () => {
             expect(config.outbound_providers).toBeDefined();
             expect(config.outbound_providers).toHaveLength(2);
             expect(config.outbound_providers.map(p => p.tag)).toContain('user-provider');
-            expect(config.outbound_providers.map(p => p.tag)).toContain('_auto_provider_1');
+            const autoProvider = config.outbound_providers
+                .find(provider => provider.tag.startsWith('_auto_provider_'));
+            expect(autoProvider.download_url).toBe('https://auto.example.com/singbox-sub');
 
             const nodeSelect = config.outbounds.find(o => o.tag === '🚀 节点选择');
             expect(nodeSelect.providers).toContain('user-provider');
-            expect(nodeSelect.providers).toContain('_auto_provider_1');
+            expect(nodeSelect.providers).toContain(autoProvider.tag);
         });
     });
 });


### PR DESCRIPTION
## Summary
- generate auto provider names from stable source URL hashes instead of per-build indexes
- apply the same stable naming to Clash proxy-providers and Sing-Box outbound_providers
- deduplicate repeated provider URLs and keep generated group references aligned

## Tests
- npx vitest run test/proxy-providers.test.js test/issue-370-empty-clash-output.test.js
- npx vitest run

Fixes #347