### PR TITLE
fix: preserve subscription userinfo for xray

### DIFF
--- a/src/app/createApp.jsx
+++ b/src/app/createApp.jsx
@@ -268,6 +268,7 @@ export function createApp(bindings = {}) {
 
         const proxylist = inputString.split('\n');
         const finalProxyList = [];
+        let subscriptionUserinfo;
         const userAgent = c.req.query('ua') || getRequestHeader(c.req, 'User-Agent') || DEFAULT_USER_AGENT;
         const headers = { 'User-Agent': userAgent };
 
@@ -278,6 +279,10 @@ export function createApp(bindings = {}) {
             if (trimmedProxy.startsWith('http://') || trimmedProxy.startsWith('https://')) {
                 try {
                     const response = await fetch(trimmedProxy, { method: 'GET', headers });
+                    const fetchedUserinfo = response.headers.get('subscription-userinfo');
+                    if (fetchedUserinfo && subscriptionUserinfo === undefined) {
+                        subscriptionUserinfo = fetchedUserinfo;
+                    }
                     const text = await response.text();
                     let processed = tryDecodeSubscriptionLines(text, { decodeUriComponent: true });
                     if (!Array.isArray(processed)) processed = [processed];
@@ -297,7 +302,12 @@ export function createApp(bindings = {}) {
             return c.text('Missing config parameter', 400);
         }
 
-        return c.text(encodeBase64(finalString));
+        const responseHeaders = {};
+        if (subscriptionUserinfo) {
+            responseHeaders['subscription-userinfo'] = subscriptionUserinfo;
+        }
+
+        return c.text(encodeBase64(finalString), 200, responseHeaders);
     });
 
     app.get('/shorten-v2', async (c) => {

--- a/test/issue-362-subscription-userinfo.test.js
+++ b/test/issue-362-subscription-userinfo.test.js
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createApp } from '../src/app/createApp.jsx';
+import { MemoryKVAdapter } from '../src/adapters/kv/memoryKv.js';
+import { decodeBase64 } from '../src/utils.js';
+
+const subscriptionUserinfo = 'upload=123; download=456; total=1024; expire=1893456000';
+const remoteSubscriptionUrl = 'https://airport.example.com/sub?token=abc';
+const proxyUri = 'ss://YWVzLTEyOC1nY206cGFzcw@example.com:443#Issue362';
+
+function createTestApp() {
+    return createApp({
+        kv: new MemoryKVAdapter(),
+        assetFetcher: null,
+        logger: console,
+        config: {
+            configTtlSeconds: 60,
+            shortLinkTtlSeconds: null
+        }
+    });
+}
+
+function mockRemoteSubscription() {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        text: async () => proxyUri,
+        headers: {
+            get: (name) => name.toLowerCase() === 'subscription-userinfo'
+                ? subscriptionUserinfo
+                : null
+        }
+    })));
+}
+
+describe('Issue #362 - subscription userinfo passthrough', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('preserves subscription-userinfo when converting remote subscriptions to Clash', async () => {
+        mockRemoteSubscription();
+        const app = createTestApp();
+
+        const res = await app.request(`http://localhost/clash?config=${encodeURIComponent(remoteSubscriptionUrl)}`);
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get('subscription-userinfo')).toBe(subscriptionUserinfo);
+        expect(await res.text()).toContain('Issue362');
+    });
+
+    it('preserves subscription-userinfo when converting remote subscriptions to Sing-Box', async () => {
+        mockRemoteSubscription();
+        const app = createTestApp();
+
+        const res = await app.request(`http://localhost/singbox?config=${encodeURIComponent(remoteSubscriptionUrl)}`);
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get('subscription-userinfo')).toBe(subscriptionUserinfo);
+        const json = await res.json();
+        expect(json.outbounds.some(outbound => outbound.tag === 'Issue362')).toBe(true);
+    });
+
+    it('preserves subscription-userinfo when converting remote subscriptions to Xray', async () => {
+        mockRemoteSubscription();
+        const app = createTestApp();
+
+        const res = await app.request(`http://localhost/xray?config=${encodeURIComponent(remoteSubscriptionUrl)}`);
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get('subscription-userinfo')).toBe(subscriptionUserinfo);
+        expect(decodeBase64(await res.text())).toBe(proxyUri);
+    });
+});


### PR DESCRIPTION
## Summary
- preserve subscription-userinfo on /xray remote subscription responses
- add regression coverage for Clash, Sing-Box, and Xray userinfo passthrough

## Tests
- npx vitest run

Closes #362
Related #53