### PR TITLE
fix: change /shorten-v2 from GET to POST to avoid 414 URI too long

### DIFF
--- a/src/app/createApp.jsx
+++ b/src/app/createApp.jsx
@@ -310,9 +310,10 @@ export function createApp(bindings = {}) {
         return c.text(encodeBase64(finalString), 200, responseHeaders);
     });
 
-    app.get('/shorten-v2', async (c) => {
+    app.post('/shorten-v2', async (c) => {
         try {
-            const url = c.req.query('url');
+            const body = await c.req.json();
+            const url = body.url;
             if (!url) {
                 return c.text('Missing URL parameter', 400);
             }
@@ -325,7 +326,7 @@ export function createApp(bindings = {}) {
             const queryString = parsedUrl.search;
 
             const shortLinks = requireShortLinkService(services.shortLinks);
-            const code = await shortLinks.createShortLink(queryString, c.req.query('shortCode'));
+            const code = await shortLinks.createShortLink(queryString, body.shortCode);
             return c.text(code);
         } catch (error) {
             return handleError(c, error, runtime.logger);

--- a/src/components/formLogic.js
+++ b/src/components/formLogic.js
@@ -439,15 +439,17 @@ export const formLogicFn = (t) => {
                     // Shorten each link type
                     for (const [type, url] of Object.entries(this.generatedLinks)) {
                         try {
-                            let apiUrl = `${origin}/shorten-v2?url=${encodeURIComponent(url)}`;
-
-                            // For the first request, either use custom code or let backend generate
-                            // For subsequent requests, use the code from first request
+                            // Build JSON body; omit shortCode if empty to let backend generate
+                            const body = { url };
                             if (shortCode) {
-                                apiUrl += `&shortCode=${encodeURIComponent(shortCode)}`;
+                                body.shortCode = shortCode;
                             }
 
-                            const response = await fetch(apiUrl);
+                            const response = await fetch(`${origin}/shorten-v2`, {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify(body),
+                            });
                             if (!response.ok) {
                                 throw new Error(`Failed to shorten ${type} link`);
                             }

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -100,7 +100,7 @@ proxy-groups:
         expect(text).toContain('requires at least one proxy or provider reference');
     });
 
-    it('GET /shorten-v2 returns short code', async () => {
+    it('POST /shorten-v2 returns short code', async () => {
         const url = 'http://example.com';
         const kvMock = {
             put: vi.fn(async () => {}),
@@ -108,7 +108,11 @@ proxy-groups:
             delete: vi.fn(async () => {})
         };
         const app = createTestApp({ kv: kvMock });
-        const res = await app.request(`http://localhost/shorten-v2?url=${encodeURIComponent(url)}`);
+        const res = await app.request('http://localhost/shorten-v2', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ url }),
+        });
         expect(res.status).toBe(200);
         const text = await res.text();
         expect(text).toBeTruthy();


### PR DESCRIPTION
## 问题

部署到 Cloudflare 后，`/shorten-v2` API 因 URL 过长返回 414 错误。原因：订阅 URL（可能很长）通过 GET query string 传递，超出 Cloudflare 的请求 URI 限制。

## 改动

将 `/shorten-v2` 从 GET 改为 POST，URL 和 shortCode 通过 JSON body 传递：

- **后端** (`src/app/createApp.jsx`): `app.get` → `app.post`，从 `c.req.json()` 读取参数
- **前端** (`src/components/formLogic.js`): `fetch` 改为 POST + JSON body
- **测试** (`test/worker.test.js`): 更新测试用例为 POST 请求