### PR TITLE
feat: support pinSHA256 field for hysteria2 protocol

### DIFF
--- a/src/builders/ClashConfigBuilder.js
+++ b/src/builders/ClashConfigBuilder.js
@@ -1,7 +1,7 @@
 import yaml from 'js-yaml';
 import { CLASH_CONFIG, generateRules, generateClashRuleSets, getOutbounds, PREDEFINED_RULE_SETS, DIRECT_DEFAULT_RULES } from '../config/index.js';
 import { BaseConfigBuilder } from './BaseConfigBuilder.js';
-import { deepCopy, groupProxiesByCountry, base64ToHex } from '../utils.js';
+import { deepCopy, groupProxiesByCountry } from '../utils.js';
 import { addProxyWithDedup } from './helpers/proxyHelpers.js';
 import { buildSelectorMembers, buildNodeSelectMembers, buildCustomRuleMembers, uniqueNames } from './helpers/groupBuilder.js';
 import { emitClashRules, sanitizeClashProxyGroups } from './helpers/clashConfigUtils.js';
@@ -232,7 +232,7 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
                     'recv-window-conn': proxy.recv_window_conn,
                     sni: proxy.tls?.server_name || '',
                     'skip-cert-verify': !!proxy.tls?.insecure,
-                    ...(proxy.tls?.pinSHA256 ? { fingerprint: base64ToHex(proxy.tls.pinSHA256) } : {}),
+                    ...(proxy.tls?.pinSHA256 ? { fingerprint: proxy.tls.pinSHA256 } : {}),
                     ...(proxy.hop_interval !== undefined ? { 'hop-interval': proxy.hop_interval } : {}),
                     ...(proxy.alpn ? { alpn: proxy.alpn } : {}),
                     ...(proxy.fast_open !== undefined ? { 'fast-open': proxy.fast_open } : {}),

--- a/src/builders/ClashConfigBuilder.js
+++ b/src/builders/ClashConfigBuilder.js
@@ -1,7 +1,7 @@
 import yaml from 'js-yaml';
 import { CLASH_CONFIG, generateRules, generateClashRuleSets, getOutbounds, PREDEFINED_RULE_SETS, DIRECT_DEFAULT_RULES } from '../config/index.js';
 import { BaseConfigBuilder } from './BaseConfigBuilder.js';
-import { deepCopy, groupProxiesByCountry } from '../utils.js';
+import { deepCopy, groupProxiesByCountry, base64ToHex } from '../utils.js';
 import { addProxyWithDedup } from './helpers/proxyHelpers.js';
 import { buildSelectorMembers, buildNodeSelectMembers, buildCustomRuleMembers, uniqueNames } from './helpers/groupBuilder.js';
 import { emitClashRules, sanitizeClashProxyGroups } from './helpers/clashConfigUtils.js';
@@ -232,6 +232,7 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
                     'recv-window-conn': proxy.recv_window_conn,
                     sni: proxy.tls?.server_name || '',
                     'skip-cert-verify': !!proxy.tls?.insecure,
+                    ...(proxy.tls?.pinSHA256 ? { fingerprint: base64ToHex(proxy.tls.pinSHA256) } : {}),
                     ...(proxy.hop_interval !== undefined ? { 'hop-interval': proxy.hop_interval } : {}),
                     ...(proxy.alpn ? { alpn: proxy.alpn } : {}),
                     ...(proxy.fast_open !== undefined ? { 'fast-open': proxy.fast_open } : {}),

--- a/src/builders/SingboxConfigBuilder.js
+++ b/src/builders/SingboxConfigBuilder.js
@@ -1,7 +1,7 @@
 
 import { SING_BOX_CONFIG, generateRuleSets, generateRules, getOutbounds, PREDEFINED_RULE_SETS, DIRECT_DEFAULT_RULES, REJECT_ACTION_RULES } from '../config/index.js';
 import { BaseConfigBuilder } from './BaseConfigBuilder.js';
-import { deepCopy, groupProxiesByCountry } from '../utils.js';
+import { deepCopy, groupProxiesByCountry, base64ToHex } from '../utils.js';
 import { addProxyWithDedup } from './helpers/proxyHelpers.js';
 import { buildSelectorMembers as buildSelectorMemberList, buildNodeSelectMembers, buildCustomRuleMembers, uniqueNames } from './helpers/groupBuilder.js';
 import { normalizeGroupName } from './helpers/groupNameUtils.js';
@@ -119,6 +119,13 @@ export class SingboxConfigBuilder extends BaseConfigBuilder {
         // Remove packet_encoding for now - it's version-specific in sing-box
         // xudp is default in newer versions
         delete sanitized.packet_encoding;
+
+        if (sanitized.tls?.pinSHA256) {
+            const hex = base64ToHex(sanitized.tls.pinSHA256);
+            const colonHex = hex.toUpperCase().match(/.{2}/g).join(':');
+            sanitized.tls = { ...sanitized.tls, certificate_hash: [colonHex] };
+            delete sanitized.tls.pinSHA256;
+        }
 
         return sanitized;
     }

--- a/src/builders/SingboxConfigBuilder.js
+++ b/src/builders/SingboxConfigBuilder.js
@@ -1,7 +1,7 @@
 
 import { SING_BOX_CONFIG, generateRuleSets, generateRules, getOutbounds, PREDEFINED_RULE_SETS, DIRECT_DEFAULT_RULES, REJECT_ACTION_RULES } from '../config/index.js';
 import { BaseConfigBuilder } from './BaseConfigBuilder.js';
-import { deepCopy, groupProxiesByCountry, base64ToHex } from '../utils.js';
+import { deepCopy, groupProxiesByCountry } from '../utils.js';
 import { addProxyWithDedup } from './helpers/proxyHelpers.js';
 import { buildSelectorMembers as buildSelectorMemberList, buildNodeSelectMembers, buildCustomRuleMembers, uniqueNames } from './helpers/groupBuilder.js';
 import { normalizeGroupName } from './helpers/groupNameUtils.js';
@@ -121,8 +121,7 @@ export class SingboxConfigBuilder extends BaseConfigBuilder {
         delete sanitized.packet_encoding;
 
         if (sanitized.tls?.pinSHA256) {
-            const hex = base64ToHex(sanitized.tls.pinSHA256);
-            const colonHex = hex.toUpperCase().match(/.{2}/g).join(':');
+            const colonHex = sanitized.tls.pinSHA256.toUpperCase().match(/.{2}/g).join(':');
             sanitized.tls = { ...sanitized.tls, certificate_hash: [colonHex] };
             delete sanitized.tls.pinSHA256;
         }

--- a/src/builders/SurgeConfigBuilder.js
+++ b/src/builders/SurgeConfigBuilder.js
@@ -1,5 +1,5 @@
 import { BaseConfigBuilder } from './BaseConfigBuilder.js';
-import { groupProxiesByCountry, base64ToHex } from '../utils.js';
+import { groupProxiesByCountry } from '../utils.js';
 import { SURGE_CONFIG, SURGE_SITE_RULE_SET_BASEURL, SURGE_IP_RULE_SET_BASEURL, generateRules, getOutbounds, PREDEFINED_RULE_SETS, DIRECT_DEFAULT_RULES } from '../config/index.js';
 import { addProxyWithDedup } from './helpers/proxyHelpers.js';
 import { buildSelectorMembers, buildNodeSelectMembers, buildCustomRuleMembers, uniqueNames } from './helpers/groupBuilder.js';
@@ -107,7 +107,7 @@ export class SurgeConfigBuilder extends BaseConfigBuilder {
                     surgeProxy += ', skip-cert-verify=true';
                 }
                 if (proxy.tls?.pinSHA256) {
-                    surgeProxy += `, server-cert-fingerprint-sha256=${base64ToHex(proxy.tls.pinSHA256)}`;
+                    surgeProxy += `, server-cert-fingerprint-sha256=${proxy.tls.pinSHA256}`;
                 }
                 if (proxy.tls?.alpn) {
                     surgeProxy += `, alpn=${proxy.tls.alpn.join(',')}`;

--- a/src/builders/SurgeConfigBuilder.js
+++ b/src/builders/SurgeConfigBuilder.js
@@ -1,5 +1,5 @@
 import { BaseConfigBuilder } from './BaseConfigBuilder.js';
-import { groupProxiesByCountry } from '../utils.js';
+import { groupProxiesByCountry, base64ToHex } from '../utils.js';
 import { SURGE_CONFIG, SURGE_SITE_RULE_SET_BASEURL, SURGE_IP_RULE_SET_BASEURL, generateRules, getOutbounds, PREDEFINED_RULE_SETS, DIRECT_DEFAULT_RULES } from '../config/index.js';
 import { addProxyWithDedup } from './helpers/proxyHelpers.js';
 import { buildSelectorMembers, buildNodeSelectMembers, buildCustomRuleMembers, uniqueNames } from './helpers/groupBuilder.js';
@@ -105,6 +105,9 @@ export class SurgeConfigBuilder extends BaseConfigBuilder {
                 }
                 if (proxy.tls?.insecure) {
                     surgeProxy += ', skip-cert-verify=true';
+                }
+                if (proxy.tls?.pinSHA256) {
+                    surgeProxy += `, server-cert-fingerprint-sha256=${base64ToHex(proxy.tls.pinSHA256)}`;
                 }
                 if (proxy.tls?.alpn) {
                     surgeProxy += `, alpn=${proxy.tls.alpn.join(',')}`;

--- a/src/parsers/convertSurgeProxyToObject.js
+++ b/src/parsers/convertSurgeProxyToObject.js
@@ -9,8 +9,6 @@
  * - Hysteria2: ProxyName = hysteria2, server, port, password=xxx, ...
  */
 
-import { hexToBase64 } from '../utils.js';
-
 /**
  * Parse key=value parameters from a Surge proxy line
  * @param {string[]} parts - Array of parameter strings
@@ -180,7 +178,7 @@ export function convertSurgeProxyToObject(line) {
                     server_name: params.sni || params['server-name'] || server,
                     insecure: parseBool(params['skip-cert-verify']),
                     alpn: params.alpn ? params.alpn.split(',').map(a => a.trim()) : undefined,
-                    ...(params['server-cert-fingerprint-sha256'] ? { pinSHA256: hexToBase64(params['server-cert-fingerprint-sha256']) } : {})
+                    ...(params['server-cert-fingerprint-sha256'] ? { pinSHA256: params['server-cert-fingerprint-sha256'].toLowerCase() } : {})
                 },
                 obfs: params['obfs-password'] ? {
                     type: params.obfs || 'salamander',

--- a/src/parsers/convertSurgeProxyToObject.js
+++ b/src/parsers/convertSurgeProxyToObject.js
@@ -9,6 +9,8 @@
  * - Hysteria2: ProxyName = hysteria2, server, port, password=xxx, ...
  */
 
+import { hexToBase64 } from '../utils.js';
+
 /**
  * Parse key=value parameters from a Surge proxy line
  * @param {string[]} parts - Array of parameter strings
@@ -177,7 +179,8 @@ export function convertSurgeProxyToObject(line) {
                     enabled: true,
                     server_name: params.sni || params['server-name'] || server,
                     insecure: parseBool(params['skip-cert-verify']),
-                    alpn: params.alpn ? params.alpn.split(',').map(a => a.trim()) : undefined
+                    alpn: params.alpn ? params.alpn.split(',').map(a => a.trim()) : undefined,
+                    ...(params['server-cert-fingerprint-sha256'] ? { pinSHA256: hexToBase64(params['server-cert-fingerprint-sha256']) } : {})
                 },
                 obfs: params['obfs-password'] ? {
                     type: params.obfs || 'salamander',

--- a/src/parsers/convertYamlProxyToObject.js
+++ b/src/parsers/convertYamlProxyToObject.js
@@ -1,5 +1,3 @@
-import { hexToBase64 } from '../utils.js';
-
 export function convertYamlProxyToObject(p) {
     if (!p || typeof p !== 'object' || !p.type) return null;
     const type = String(p.type).toLowerCase();
@@ -185,7 +183,7 @@ export function convertYamlProxyToObject(p) {
                 enabled: true,
                 server_name: p.sni,
                 insecure: !!p['skip-cert-verify'],
-                ...(p.fingerprint ? { pinSHA256: hexToBase64(p.fingerprint) } : {})
+                ...(p.fingerprint ? { pinSHA256: p.fingerprint.toLowerCase() } : {})
             };
             const obfs = {};
             if (p.obfs) {

--- a/src/parsers/convertYamlProxyToObject.js
+++ b/src/parsers/convertYamlProxyToObject.js
@@ -1,3 +1,5 @@
+import { hexToBase64 } from '../utils.js';
+
 export function convertYamlProxyToObject(p) {
     if (!p || typeof p !== 'object' || !p.type) return null;
     const type = String(p.type).toLowerCase();
@@ -182,7 +184,8 @@ export function convertYamlProxyToObject(p) {
             const tls = {
                 enabled: true,
                 server_name: p.sni,
-                insecure: !!p['skip-cert-verify']
+                insecure: !!p['skip-cert-verify'],
+                ...(p.fingerprint ? { pinSHA256: hexToBase64(p.fingerprint) } : {})
             };
             const obfs = {};
             if (p.obfs) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -292,7 +292,7 @@ export function createTlsConfig(params) {
 		tls = {
 			enabled: true,
 			server_name: params.sni || params.host,
-			insecure: !!params?.allowInsecure || !!params?.insecure || !!params?.allow_insecure,
+			insecure: parseBool(params?.allowInsecure) || parseBool(params?.insecure) || parseBool(params?.allow_insecure) || false,
 		};
 		if (params.pinSHA256) {
 			tls.pinSHA256 = normalizePinSHA256(params.pinSHA256);

--- a/src/utils.js
+++ b/src/utils.js
@@ -293,11 +293,10 @@ export function createTlsConfig(params) {
 			enabled: true,
 			server_name: params.sni || params.host,
 			insecure: !!params?.allowInsecure || !!params?.insecure || !!params?.allow_insecure,
-			// utls: {
-			//   enabled: true,
-			//   fingerprint: "chrome"
-			// },
 		};
+		if (params.pinSHA256) {
+			tls.pinSHA256 = params.pinSHA256;
+		}
 		if (params.security === 'reality') {
 			tls.reality = {
 				enabled: true,
@@ -307,6 +306,24 @@ export function createTlsConfig(params) {
 		}
 	}
 	return tls;
+}
+
+export function base64ToHex(b64) {
+	const raw = atob(b64);
+	let hex = '';
+	for (let i = 0; i < raw.length; i++) {
+		hex += raw.charCodeAt(i).toString(16).padStart(2, '0');
+	}
+	return hex;
+}
+
+export function hexToBase64(hex) {
+	const clean = hex.replace(/[:\s]/g, '');
+	const bytes = [];
+	for (let i = 0; i < clean.length; i += 2) {
+		bytes.push(parseInt(clean.slice(i, i + 2), 16));
+	}
+	return btoa(String.fromCharCode(...bytes));
 }
 
 export function createTransportConfig(params) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -295,7 +295,7 @@ export function createTlsConfig(params) {
 			insecure: !!params?.allowInsecure || !!params?.insecure || !!params?.allow_insecure,
 		};
 		if (params.pinSHA256) {
-			tls.pinSHA256 = params.pinSHA256;
+			tls.pinSHA256 = normalizePinSHA256(params.pinSHA256);
 		}
 		if (params.security === 'reality') {
 			tls.reality = {
@@ -308,22 +308,18 @@ export function createTlsConfig(params) {
 	return tls;
 }
 
-export function base64ToHex(b64) {
-	const raw = atob(b64);
+export function normalizePinSHA256(value) {
+	if (!value) return undefined;
+	const clean = value.replace(/[:\s]/g, '');
+	if (/^[0-9a-fA-F]+$/.test(clean)) {
+		return clean.toLowerCase();
+	}
+	const raw = atob(clean);
 	let hex = '';
 	for (let i = 0; i < raw.length; i++) {
 		hex += raw.charCodeAt(i).toString(16).padStart(2, '0');
 	}
 	return hex;
-}
-
-export function hexToBase64(hex) {
-	const clean = hex.replace(/[:\s]/g, '');
-	const bytes = [];
-	for (let i = 0; i < clean.length; i += 2) {
-		bytes.push(parseInt(clean.slice(i, i + 2), 16));
-	}
-	return btoa(String.fromCharCode(...bytes));
 }
 
 export function createTransportConfig(params) {


### PR DESCRIPTION
## Summary

- Parse `pinSHA256` from hy2 URI (auto-detect hex vs base64 format)
- Parse `fingerprint` from Clash YAML input and `server-cert-fingerprint-sha256` from Surge input
- Output correctly to each format:
  - **Clash/Mihomo**: `fingerprint` (lowercase hex)
  - **Surge**: `server-cert-fingerprint-sha256` (hex)
  - **Sing-Box**: `tls.certificate_hash` (`XX:XX:...` uppercase hex with colon separators)
- Fix: `insecure=0` was incorrectly parsed as `true` due to `!!` coercion on string "0"; now uses `parseBool()`

## Test plan

- [x] All 206 existing tests pass
- [x] Verified with real hy2 URI containing hex pinSHA256
- [x] Confirmed Clash output produces correct `fingerprint` field