### PR TITLE
fix(singbox): restore UDP after 1.13 regression

### DIFF
--- a/src/builders/SingboxConfigBuilder.js
+++ b/src/builders/SingboxConfigBuilder.js
@@ -98,10 +98,12 @@ export class SingboxConfigBuilder extends BaseConfigBuilder {
         // Create a shallow copy to avoid mutating the original
         const sanitized = { ...proxy };
 
-        // Remove Clash-specific fields that are not valid in sing-box outbound configuration
-        // In sing-box, UDP is controlled by 'network' field (defaults to both tcp and udp)
-        // The 'udp: true/false' field is a Clash/Clash Meta specific setting
+        // Strip Clash-only / mis-typed fields that conflict with sing-box semantics.
+        // `udp` is Clash-only. Top-level `network` in sing-box is a TCP/UDP allowlist
+        // (NetworkList in option/types.go); a stray "tcp" silently disables UDP for
+        // every group that selects this node — including DNS hijack and fakeip.
         delete sanitized.udp;
+        delete sanitized.network;
 
         // Remove 'alpn' from root level - it should only exist inside 'tls' object for sing-box
         // For protocols like vless/vmess, alpn belongs inside the tls configuration
@@ -559,11 +561,15 @@ export class SingboxConfigBuilder extends BaseConfigBuilder {
             }, rule));
         });
 
+        // Order matters: sniff first so downstream rules can match on protocol;
+        // hijack-dns before clash_mode so DNS never escapes into a selector when
+        // the user toggles global mode (selectors only support TCP+UDP if the
+        // currently selected node does, which is fragile).
         this.config.route.rules.unshift(
-            { clash_mode: 'direct', outbound: 'DIRECT' },
-            { clash_mode: 'global', outbound: this.t('outboundNames.Node Select') },
             { action: 'sniff' },
-            { protocol: 'dns', action: 'hijack-dns' }
+            { protocol: 'dns', action: 'hijack-dns' },
+            { clash_mode: 'direct', outbound: 'DIRECT' },
+            { clash_mode: 'global', outbound: this.t('outboundNames.Node Select') }
         );
 
         this.config.route.auto_detect_interface = true;

--- a/src/parsers/protocols/shadowsocksParser.js
+++ b/src/parsers/protocols/shadowsocksParser.js
@@ -68,7 +68,6 @@ function createConfig(tag, server, server_port, method, password, pluginInfo) {
         server_port: parseInt(server_port),
         method,
         password,
-        network: 'tcp',
         tcp_fast_open: false
     };
 

--- a/src/parsers/protocols/trojanParser.js
+++ b/src/parsers/protocols/trojanParser.js
@@ -16,7 +16,6 @@ export function parseTrojan(url) {
         server: host,
         server_port: port,
         password: decodeURIComponent(password) || parsedURL.username,
-        network: 'tcp',
         tcp_fast_open: false,
         tls,
         transport,

--- a/src/parsers/protocols/vlessParser.js
+++ b/src/parsers/protocols/vlessParser.js
@@ -14,8 +14,7 @@ export function parseVless(url) {
     }
     const transport = params.type !== 'tcp' ? createTransportConfig(params) : undefined;
 
-    // Parse UDP setting - primarily used for Clash output
-    // In sing-box, UDP is controlled by 'network' field, but we preserve this for Clash compatibility
+    // `udp` is a Clash-only flag; ClashConfigBuilder reads it, SingboxConfigBuilder strips it.
     const udp = params.udp !== undefined ? parseBool(params.udp) : undefined;
 
     return {
@@ -27,10 +26,7 @@ export function parseVless(url) {
         tcp_fast_open: false,
         tls,
         transport,
-        network: 'tcp',
         flow: params.flow ?? undefined,
-        // Include udp if explicitly specified - will be used for Clash output
-        // SingBoxConfigBuilder will strip this field for sing-box output
         ...(udp !== undefined ? { udp } : {})
     };
 }

--- a/src/parsers/protocols/vmessParser.js
+++ b/src/parsers/protocols/vmessParser.js
@@ -86,7 +86,6 @@ export function parseVmess(url) {
         uuid: vmessConfig.id,
         alter_id: parseInt(vmessConfig.aid) || 0,
         security: vmessConfig.scy || 'auto',
-        network: 'tcp',
         tcp_fast_open: false,
         transport,
         tls: tls.enabled ? tls : undefined

--- a/test/issue-297-vmess-network.test.js
+++ b/test/issue-297-vmess-network.test.js
@@ -3,16 +3,16 @@ import { parseVmess } from '../src/parsers/protocols/vmessParser.js';
 import { SingboxConfigBuilder } from '../src/builders/SingboxConfigBuilder.js';
 
 /**
- * Issue #297: Singbox 订阅无法导入
+ * Issue #297 (follow-up): the original fix hardcoded `network: 'tcp'` on every
+ * parsed proxy so sing-box would stop seeing transport names like 'ws' in that
+ * slot. That value is harmless in Clash but in sing-box `network` is a TCP/UDP
+ * allowlist (option/types.go NetworkList), and "tcp" silently disables UDP —
+ * breaking DNS hijack, fakeip, QUIC, and any selector that picks the node.
  *
- * 问题：VMess 使用 WebSocket 传输时，network 字段被错误设置为 'ws'
- * 错误信息：unknown net: ws
- *
- * Sing-Box 的 network 字段只接受 'tcp' 或 'udp'
- * WebSocket 应该只在 transport 对象中配置
+ * The proper fix is to never emit a top-level `network` in sing-box output and
+ * let it default to ["tcp","udp"]. Transport info lives in `transport.type`.
  */
-describe('Issue #297: VMess network field should be tcp/udp only', () => {
-    // Base64 encoded VMess config with WebSocket transport
+describe('Issue #297: sing-box outbounds must not carry a top-level `network`', () => {
     const vmessWsConfig = {
         v: '2',
         ps: 'VMess-WS-Test',
@@ -31,19 +31,17 @@ describe('Issue #297: VMess network field should be tcp/udp only', () => {
 
     const vmessWsUrl = 'vmess://' + Buffer.from(JSON.stringify(vmessWsConfig)).toString('base64');
 
-    it('parseVmess should set network to tcp for WebSocket transport', () => {
+    it('parseVmess should not emit a top-level network field for WebSocket transport', () => {
         const result = parseVmess(vmessWsUrl);
 
-        // network 字段应该是 'tcp'，不是 'ws'
-        expect(result.network).toBe('tcp');
+        expect(result.network).toBeUndefined();
 
-        // transport.type 应该是 'ws'
         expect(result.transport).toBeDefined();
         expect(result.transport.type).toBe('ws');
         expect(result.transport.path).toBe('/ws');
     });
 
-    it('parseVmess should set network to tcp for gRPC transport', () => {
+    it('parseVmess should not emit a top-level network field for gRPC transport', () => {
         const vmessGrpcConfig = {
             ...vmessWsConfig,
             ps: 'VMess-gRPC-Test',
@@ -54,12 +52,12 @@ describe('Issue #297: VMess network field should be tcp/udp only', () => {
 
         const result = parseVmess(vmessGrpcUrl);
 
-        expect(result.network).toBe('tcp');
+        expect(result.network).toBeUndefined();
         expect(result.transport).toBeDefined();
         expect(result.transport.type).toBe('grpc');
     });
 
-    it('parseVmess should set network to tcp for HTTP transport', () => {
+    it('parseVmess should not emit a top-level network field for HTTP transport', () => {
         const vmessHttpConfig = {
             ...vmessWsConfig,
             ps: 'VMess-HTTP-Test',
@@ -70,12 +68,12 @@ describe('Issue #297: VMess network field should be tcp/udp only', () => {
 
         const result = parseVmess(vmessHttpUrl);
 
-        expect(result.network).toBe('tcp');
+        expect(result.network).toBeUndefined();
         expect(result.transport).toBeDefined();
         expect(result.transport.type).toBe('http');
     });
 
-    it('parseVmess should set network to tcp for H2 transport', () => {
+    it('parseVmess should not emit a top-level network field for H2 transport', () => {
         const vmessH2Config = {
             ...vmessWsConfig,
             ps: 'VMess-H2-Test',
@@ -86,12 +84,12 @@ describe('Issue #297: VMess network field should be tcp/udp only', () => {
 
         const result = parseVmess(vmessH2Url);
 
-        expect(result.network).toBe('tcp');
+        expect(result.network).toBeUndefined();
         expect(result.transport).toBeDefined();
         expect(result.transport.type).toBe('h2');
     });
 
-    it('parseVmess should set network to tcp for plain TCP (no transport)', () => {
+    it('parseVmess should not emit a top-level network field for plain TCP (no transport)', () => {
         const vmessTcpConfig = {
             ...vmessWsConfig,
             ps: 'VMess-TCP-Test',
@@ -102,12 +100,11 @@ describe('Issue #297: VMess network field should be tcp/udp only', () => {
 
         const result = parseVmess(vmessTcpUrl);
 
-        expect(result.network).toBe('tcp');
-        // Plain TCP should not have transport object
+        expect(result.network).toBeUndefined();
         expect(result.transport).toBeUndefined();
     });
 
-    it('SingboxConfigBuilder should output valid network field for VMess with WS', async () => {
+    it('SingboxConfigBuilder must not emit network on VMess outbound with WS transport', async () => {
         const builder = new SingboxConfigBuilder(
             vmessWsUrl,
             [],
@@ -122,14 +119,7 @@ describe('Issue #297: VMess network field should be tcp/udp only', () => {
         const vmessProxy = result.outbounds.find(o => o.tag === 'VMess-WS-Test');
 
         expect(vmessProxy).toBeDefined();
-        // network 必须是 'tcp' 或 'udp'，不能是 'ws'
-        expect(['tcp', 'udp', undefined]).toContain(vmessProxy.network);
-        expect(vmessProxy.network).not.toBe('ws');
-        expect(vmessProxy.network).not.toBe('grpc');
-        expect(vmessProxy.network).not.toBe('http');
-        expect(vmessProxy.network).not.toBe('h2');
-
-        // transport 配置应该正确
+        expect(vmessProxy.network).toBeUndefined();
         expect(vmessProxy.transport?.type).toBe('ws');
     });
 });

--- a/test/singbox-route-order.test.js
+++ b/test/singbox-route-order.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { SingboxConfigBuilder } from '../src/builders/SingboxConfigBuilder.js';
+
+/**
+ * Companion to the #297 follow-up: when a user toggled clash_mode=global, DNS
+ * UDP packets matched the clash_mode rule before hijack-dns and were dispatched
+ * to a selector, which then failed on UDP because every node had been emitted
+ * with `network: "tcp"`. The selector failure is fixed elsewhere by dropping
+ * the bad field; this test pins the route ordering so even a future global-mode
+ * toggle keeps DNS on the hijack path.
+ */
+describe('sing-box route.rules: hijack-dns precedes clash_mode rules', () => {
+    const vlessUrl = 'vless://12345678-1234-1234-1234-123456789abc@example.com:443?security=tls&sni=example.com#TestVless';
+
+    it('hijack-dns sits before any clash_mode rule', async () => {
+        const builder = new SingboxConfigBuilder(vlessUrl, [], [], null, 'zh-CN', null, false);
+        const result = await builder.build();
+        const rules = result.route.rules;
+
+        const dnsHijackIdx = rules.findIndex(r => r.action === 'hijack-dns' && r.protocol === 'dns');
+        const firstClashModeIdx = rules.findIndex(r => r.clash_mode);
+
+        expect(dnsHijackIdx).toBeGreaterThanOrEqual(0);
+        expect(firstClashModeIdx).toBeGreaterThanOrEqual(0);
+        expect(dnsHijackIdx).toBeLessThan(firstClashModeIdx);
+    });
+
+    it('sniff action is present and precedes hijack-dns', async () => {
+        const builder = new SingboxConfigBuilder(vlessUrl, [], [], null, 'zh-CN', null, false);
+        const result = await builder.build();
+        const rules = result.route.rules;
+
+        const sniffIdx = rules.findIndex(r => r.action === 'sniff' && !r.protocol);
+        const dnsHijackIdx = rules.findIndex(r => r.action === 'hijack-dns');
+
+        expect(sniffIdx).toBeGreaterThanOrEqual(0);
+        expect(sniffIdx).toBeLessThan(dnsHijackIdx);
+    });
+});


### PR DESCRIPTION
## Summary

修复 sing-box 1.13 上 UDP 流量被错误拒绝的回归。

用户在 `clash_mode=global` 下报错 `UDP is not supported by outbound: 🚀 节点选择`，所有 UDP（DNS、QUIC、HTTP/3）全部失效。根因有两处，互相叠加：

### 根因 1：所有节点被硬编码为 tcp-only

`vless/vmess/trojan/shadowsocks` 四个 URI parser 都硬塞了 `network: 'tcp'`。这是 #297 修复时引入的 workaround —— 当时是为了阻止 vmess 把传输层 `ws`/`grpc` 写到这个字段、让 sing-box 报错 `unknown net: ws`。

但 `network` 在 sing-box 里是 `NetworkList`（`option/types.go`），语义是「该出站允许的 TCP/UDP 协议」，写 `"tcp"` 等于**显式禁用 UDP**。selector / urltest 通过 `Network()` 继承 selected 子节点的能力，所以整个分组都变成 tcp-only，路由器在 `route/route.go:240` 直接拒绝任何 UDP。

**修法**：

- 4 个 parser 不再发出顶层 `network` 字段
- `SingboxConfigBuilder.convertProxy()` 加防御性 `delete sanitized.network`，连同 YAML 订阅路径里的 `network: transport?.type || p.network || 'tcp'` 兜底剥除
- ClashConfigBuilder 完全不动 —— `network: proxy.transport?.type || proxy.network || 'tcp'` 的 fallback 链让它行为不变

### 根因 2：route.rules 顺序错

```
clash_mode=direct  → DIRECT
clash_mode=global  → 🚀 节点选择   ← 在前
sniff
protocol=dns       → hijack-dns    ← 在后
```

用户在 dashboard 切到 global，DNS UDP 先撞 global 规则被路由到 selector，再叠加根因 1 直接炸。

**修法**：把 `sniff` 和 `hijack-dns` 提到 `clash_mode` 规则之前，DNS 不再受 mode 切换影响。

### 为什么 1.12 没暴露，1.13 暴露

`network: "tcp"` 在 1.12 也是同样语义、同样禁用 UDP，但 1.13 的 `cache_file` 把 `clash_mode` 状态持久化到 `bucketMode`（`experimental/cachefile/cache.go:26`），用户重启后停在 global mode 概率变高，触发链才完整闭合。

## Test plan

- [x] `npm test` — 208 个测试全过（含新增的 `singbox-route-order` 2 个 + 改造后的 `issue-297-vmess-network` 6 个）
- [x] `issue-297-vmess-network.test.js` 断言收紧：sing-box outbound 不应包含顶层 `network` 字段
- [x] `singbox-route-order.test.js` 新增：pin `sniff` → `hijack-dns` → `clash_mode` 顺序
- [x] `udp-handling.test.js` 既有 9 个测试不受影响（只验 `udp` 字段，本 PR 不动）
- [x] ClashConfigBuilder 输出路径未改动；Clash 端 `network: proxy.transport?.type || proxy.network || 'tcp'` 的 fallback 链保证 parser 不再带 `network` 时仍正确