### PR TITLE
fix: preserve VLESS ML-KEM encryption and improve Clash/mihomo compatibility

### DIFF
--- a/src/builders/ClashConfigBuilder.js
+++ b/src/builders/ClashConfigBuilder.js
@@ -152,6 +152,7 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
                     alterId: proxy.alter_id ?? 0,
                     cipher: proxy.security,
                     tls: proxy.tls?.enabled || false,
+                    'client-fingerprint': proxy.tls?.utls?.fingerprint,
                     servername: proxy.tls?.server_name || '',
                     'skip-cert-verify': !!proxy.tls?.insecure,
                     network: proxy.transport?.type || proxy.network || 'tcp',
@@ -193,6 +194,8 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
                     server: proxy.server,
                     port: proxy.server_port,
                     uuid: proxy.uuid,
+                    // Post-quantum / custom VLESS encryption string (e.g. mlkem768x25519plus...)
+                    ...(proxy.encryption && proxy.encryption !== 'none' ? { encryption: proxy.encryption } : {}),
                     cipher: proxy.security,
                     tls: proxy.tls?.enabled || false,
                     'client-fingerprint': proxy.tls?.utls?.fingerprint,
@@ -201,6 +204,12 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
                     'ws-opts': proxy.transport?.type === 'ws' ? {
                         path: proxy.transport.path,
                         headers: proxy.transport.headers
+                    } : undefined,
+                    'xhttp-opts': (proxy.transport?.type === 'xhttp' || proxy.transport?.type === 'splithttp') ? {
+                        path: proxy.transport.path,
+                        mode: proxy.transport.mode || 'auto',
+                        ...(proxy.transport.host ? { host: proxy.transport.host } : {}),
+                        ...(proxy.transport.headers ? { headers: proxy.transport.headers } : {})
                     } : undefined,
                     'reality-opts': proxy.tls?.reality?.enabled ? {
                         'public-key': proxy.tls.reality.public_key,

--- a/src/builders/ClashConfigBuilder.js
+++ b/src/builders/ClashConfigBuilder.js
@@ -154,7 +154,9 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
                     tls: proxy.tls?.enabled || false,
                     'client-fingerprint': proxy.tls?.utls?.fingerprint,
                     servername: proxy.tls?.server_name || '',
-                    'skip-cert-verify': !!proxy.tls?.insecure,
+                    // Clash/mihomo: force skip-cert-verify for better share-link compatibility
+                    // (many nodes advertise insecure=0 but fail strict verification)
+                    'skip-cert-verify': true,
                     network: proxy.transport?.type || proxy.network || 'tcp',
                     'ws-opts': proxy.transport?.type === 'ws'
                         ? {
@@ -219,7 +221,8 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
                         'grpc-service-name': proxy.transport.service_name,
                     } : undefined,
                     tfo: proxy.tcp_fast_open,
-                    'skip-cert-verify': !!proxy.tls?.insecure,
+                    // Clash/mihomo compatibility: always skip cert verify
+                    'skip-cert-verify': true,
                     udp: getClashUdpValue(proxy),
                     ...(proxy.alpn ? { alpn: proxy.alpn } : {}),
                     ...(proxy.packet_encoding ? { 'packet-encoding': proxy.packet_encoding } : {}),
@@ -240,7 +243,8 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
                     down: proxy.down,
                     'recv-window-conn': proxy.recv_window_conn,
                     sni: proxy.tls?.server_name || '',
-                    'skip-cert-verify': !!proxy.tls?.insecure,
+                    // Clash/mihomo compatibility: always skip cert verify
+                    'skip-cert-verify': true,
                     ...(proxy.hop_interval !== undefined ? { 'hop-interval': proxy.hop_interval } : {}),
                     ...(proxy.alpn ? { alpn: proxy.alpn } : {}),
                     ...(proxy.fast_open !== undefined ? { 'fast-open': proxy.fast_open } : {}),
@@ -269,7 +273,8 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
                         'grpc-service-name': proxy.transport.service_name,
                     } : undefined,
                     tfo: proxy.tcp_fast_open,
-                    'skip-cert-verify': !!proxy.tls?.insecure,
+                    // Clash/mihomo compatibility: always skip cert verify
+                    'skip-cert-verify': true,
                     ...(proxy.alpn ? { alpn: proxy.alpn } : {}),
                     'flow': proxy.flow ?? undefined,
                     udp: getClashUdpValue(proxy),
@@ -283,7 +288,8 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
                     uuid: proxy.uuid,
                     password: proxy.password,
                     'congestion-controller': proxy.congestion_control,
-                    'skip-cert-verify': !!proxy.tls?.insecure,
+                    // Clash/mihomo compatibility: always skip cert verify
+                    'skip-cert-verify': true,
                     ...(proxy.disable_sni !== undefined ? { 'disable-sni': proxy.disable_sni } : {}),
                     ...(proxy.tls?.alpn ? { alpn: proxy.tls.alpn } : {}),
                     'sni': proxy.tls?.server_name,
@@ -302,7 +308,8 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
                     udp: getClashUdpValue(proxy),
                     ...(proxy.tls?.utls?.fingerprint ? { 'client-fingerprint': proxy.tls.utls.fingerprint } : {}),
                     ...(proxy.tls?.server_name ? { sni: proxy.tls.server_name } : {}),
-                    ...(proxy.tls?.insecure !== undefined ? { 'skip-cert-verify': !!proxy.tls.insecure } : {}),
+                    // Clash/mihomo compatibility: always skip cert verify when TLS is present
+                    ...(proxy.tls ? { 'skip-cert-verify': true } : {}),
                     ...(proxy.tls?.alpn ? { alpn: proxy.tls.alpn } : {}),
                     ...(proxy['idle-session-check-interval'] !== undefined ? { 'idle-session-check-interval': proxy['idle-session-check-interval'] } : {}),
                     ...(proxy['idle-session-timeout'] !== undefined ? { 'idle-session-timeout': proxy['idle-session-timeout'] } : {}),

--- a/src/parsers/convertYamlProxyToObject.js
+++ b/src/parsers/convertYamlProxyToObject.js
@@ -105,6 +105,16 @@ export function convertYamlProxyToObject(p) {
                     const h2 = p['h2-opts'] || {};
                     return { type: 'h2', path: h2.path, host: h2.host };
                 }
+                if (net === 'xhttp' || net === 'splithttp') {
+                    const x = p['xhttp-opts'] || p['splithttp-opts'] || {};
+                    return {
+                        type: 'xhttp',
+                        path: x.path,
+                        mode: x.mode || 'auto',
+                        host: x.host,
+                        headers: x.headers
+                    };
+                }
                 return undefined;
             })();
             return {
@@ -118,6 +128,8 @@ export function convertYamlProxyToObject(p) {
                 transport,
                 network: transport?.type || 'tcp',
                 flow: p.flow ?? undefined,
+                // Preserve post-quantum / custom encryption for round-trip YAML conversion
+                ...(p.encryption && p.encryption !== 'none' ? { encryption: p.encryption } : {}),
                 udp: typeof p.udp !== 'undefined' ? !!p.udp : undefined,
                 packet_encoding: p['packet-encoding'],
                 alpn: toArray(p.alpn)

--- a/src/parsers/protocols/tuicParser.js
+++ b/src/parsers/protocols/tuicParser.js
@@ -4,12 +4,25 @@ export function parseTuic(url) {
     const { addressPart, params, name } = parseUrlParams(url);
     const [userinfo, serverInfo] = addressPart.split('@');
     const { host, port } = parseServerInfo(serverInfo);
+    // Prefer explicit skip-cert-verify / insecure / allowInsecure; default false when omitted.
+    // (Old code defaulted true, which wrongly forced skip-cert-verify for secure links.)
+    const insecure = parseBool(
+        params['skip-cert-verify'] ?? params.insecure ?? params.allowInsecure ?? params.allow_insecure,
+        false
+    );
     const tls = {
         enabled: true,
         server_name: params.sni,
         alpn: parseArray(params.alpn),
-        insecure: parseBool(params['skip-cert-verify'] ?? params.insecure ?? params.allowInsecure, true)
+        insecure: !!insecure
     };
+
+    // Share links commonly use congestion_control or congestion-control
+    const congestion =
+        params.congestion_control ||
+        params['congestion-control'] ||
+        params.congestionController ||
+        params['congestion-controller'];
 
     return {
         tag: name,
@@ -18,7 +31,7 @@ export function parseTuic(url) {
         server_port: port,
         uuid: decodeURIComponent(userinfo).split(':')[0],
         password: decodeURIComponent(userinfo).split(':')[1],
-        congestion_control: params.congestion_control,
+        congestion_control: congestion,
         tls,
         flow: params.flow ?? undefined,
         udp_relay_mode: params['udp-relay-mode'] || params.udp_relay_mode,

--- a/src/parsers/protocols/vlessParser.js
+++ b/src/parsers/protocols/vlessParser.js
@@ -6,16 +6,29 @@ export function parseVless(url) {
     const { host, port } = parseServerInfo(serverInfo);
 
     const tls = createTlsConfig(params);
-    if (tls.reality) {
-        tls.utls = {
-            enabled: true,
-            fingerprint: 'chrome'
-        };
+    // Prefer explicit fp; fall back to chrome for reality (common client default).
+    if (tls.enabled) {
+        const fingerprint = params.fp || params.fingerprint || (tls.reality ? 'chrome' : undefined);
+        if (fingerprint) {
+            tls.utls = {
+                enabled: true,
+                fingerprint
+            };
+        }
     }
-    const transport = params.type !== 'tcp' ? createTransportConfig(params) : undefined;
+    // type=tcp means no transport object; xhttp/ws/grpc/h2/http keep transport.
+    const transport = params.type && params.type !== 'tcp'
+        ? createTransportConfig(params)
+        : undefined;
 
     // `udp` is a Clash-only flag; ClashConfigBuilder reads it, SingboxConfigBuilder strips it.
     const udp = params.udp !== undefined ? parseBool(params.udp) : undefined;
+
+    // VLESS post-quantum encryption (e.g. mlkem768x25519plus.native.0rtt.<keys...>)
+    // Must be preserved as-is for mihomo / xray clients.
+    const encryption = params.encryption && params.encryption !== 'none'
+        ? params.encryption
+        : undefined;
 
     return {
         type: 'vless',
@@ -27,6 +40,7 @@ export function parseVless(url) {
         tls,
         transport,
         flow: params.flow ?? undefined,
+        ...(encryption ? { encryption } : {}),
         ...(udp !== undefined ? { udp } : {})
     };
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -289,15 +289,23 @@ export function parseUrlParams(url) {
 export function createTlsConfig(params) {
 	let tls = { enabled: false };
 	if (params.security && params.security !== 'none') {
+		// Share links use insecure=0/1/true/false; must use parseBool, not !!string.
+		const insecure = parseBool(
+			params.allowInsecure ?? params.insecure ?? params.allow_insecure ?? params['skip-cert-verify'],
+			false
+		);
 		tls = {
 			enabled: true,
 			server_name: params.sni || params.host,
-			insecure: !!params?.allowInsecure || !!params?.insecure || !!params?.allow_insecure,
-			// utls: {
-			//   enabled: true,
-			//   fingerprint: "chrome"
-			// },
+			insecure: !!insecure,
 		};
+		const fingerprint = params.fp || params.fingerprint;
+		if (fingerprint) {
+			tls.utls = {
+				enabled: true,
+				fingerprint
+			};
+		}
 		if (params.security === 'reality') {
 			tls.reality = {
 				enabled: true,
@@ -309,13 +317,35 @@ export function createTlsConfig(params) {
 	return tls;
 }
 
+function normalizeTransportPath(path) {
+	if (path === undefined || path === null || path === '') return undefined;
+	const value = String(path);
+	// Share links sometimes omit the leading slash; Clash/mihomo usually expects "/path".
+	if (value.startsWith('/')) return value;
+	return `/${value}`;
+}
+
 export function createTransportConfig(params) {
+	const type = params.type;
+	const path = normalizeTransportPath(params.path);
+	const hostHeader = params.host || params.sni;
+
+	if (type === 'xhttp' || type === 'splithttp') {
+		return {
+			// Normalize alias used by some share links
+			type: 'xhttp',
+			path,
+			mode: params.mode || 'auto',
+			...(hostHeader ? { host: hostHeader, headers: { host: hostHeader } } : {}),
+		};
+	}
+
 	return {
-		type: params.type,
-		path: params.path ?? undefined,
-		...(params.host && { 'headers': { 'host': params.host } }),
-		...(params.type === 'grpc' && {
-			service_name: params.serviceName ?? undefined,
+		type,
+		path,
+		...(hostHeader && { headers: { host: hostHeader } }),
+		...(type === 'grpc' && {
+			service_name: params.serviceName ?? params.service_name ?? undefined,
 		})
 	};
 }

--- a/test/issue-vless-mlkem-xhttp.test.js
+++ b/test/issue-vless-mlkem-xhttp.test.js
@@ -97,9 +97,11 @@ describe('VLESS ML-KEM + xhttp conversion', () => {
 });
 
 describe('TLS insecure flag parsing', () => {
-  it('treats insecure=0 as skip-cert-verify false for TUIC', () => {
+  it('Clash export forces skip-cert-verify true for TUIC even when insecure=0', () => {
     const clash = toClash(parseTuic(TUIC_SECURE_URL));
-    expect(clash['skip-cert-verify']).toBe(false);
+    // Parser keeps insecure=false, Clash export forces true for mihomo compatibility
+    expect(parseTuic(TUIC_SECURE_URL).tls?.insecure).toBe(false);
+    expect(clash['skip-cert-verify']).toBe(true);
     expect(clash.sni).toBe('tuic.example.com');
     expect(clash['congestion-controller']).toBe('bbr');
   });
@@ -110,9 +112,11 @@ describe('TLS insecure flag parsing', () => {
     expect(clash.server).toBe('2001:db8::1');
   });
 
-  it('treats insecure=0 as skip-cert-verify false for Hysteria2', () => {
-    const clash = toClash(parseHysteria2(HY2_SECURE_URL));
-    expect(clash['skip-cert-verify']).toBe(false);
+  it('Clash export forces skip-cert-verify true for Hysteria2 even when insecure=0', () => {
+    const parsed = parseHysteria2(HY2_SECURE_URL);
+    expect(parsed.tls?.insecure).toBe(false);
+    const clash = toClash(parsed);
+    expect(clash['skip-cert-verify']).toBe(true);
     expect(clash.sni).toBe('hy2.example.com');
   });
 

--- a/test/issue-vless-mlkem-xhttp.test.js
+++ b/test/issue-vless-mlkem-xhttp.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { parseVless } from '../src/parsers/protocols/vlessParser.js';
+import { parseTuic } from '../src/parsers/protocols/tuicParser.js';
+import { parseHysteria2 } from '../src/parsers/protocols/hysteria2Parser.js';
+import { ClashConfigBuilder } from '../src/builders/ClashConfigBuilder.js';
+import { convertYamlProxyToObject } from '../src/parsers/convertYamlProxyToObject.js';
+
+// Synthetic fixtures only — no real server credentials.
+const FAKE_MLKEM_PAYLOAD = 'A'.repeat(1200);
+const MLKEM_URL =
+  `vless://00000000-0000-4000-8000-000000000001@203.0.113.10:443` +
+  `?encryption=mlkem768x25519plus.native.0rtt.${FAKE_MLKEM_PAYLOAD}` +
+  `&flow=xtls-rprx-vision&security=reality&sni=example.com&fp=chrome` +
+  `&pbk=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA` +
+  `&sid=0123456789abcdef&type=xhttp&path=test-xh&mode=auto` +
+  `#test-mlkem-xhttp`;
+
+const VLESS_WS_URL =
+  'vless://00000000-0000-4000-8000-000000000002@203.0.113.20:443' +
+  '?encryption=none&security=tls&sni=cdn.example.com&fp=chrome' +
+  '&insecure=1&type=ws&host=cdn.example.com&path=%2Fproxy#test-vless-ws';
+
+const TUIC_SECURE_URL =
+  'tuic://00000000-0000-4000-8000-000000000003%3Apassword@tuic.example.com:443' +
+  '?sni=tuic.example.com&alpn=h3&insecure=0&allowInsecure=0&congestion_control=bbr#test-tuic-secure';
+
+const TUIC_INSECURE_URL =
+  'tuic://00000000-0000-4000-8000-000000000004%3Apassword@[2001:db8::1]:60511' +
+  '?alpn=h3&insecure=1&allowInsecure=1&congestion_control=bbr#test-tuic-insecure';
+
+const HY2_SECURE_URL =
+  'hysteria2://password@hy2.example.com:443' +
+  '?sni=hy2.example.com&insecure=0&allowInsecure=0#test-hy2-secure';
+
+function toClash(proxy) {
+  return ClashConfigBuilder.prototype.convertProxy.call({}, proxy);
+}
+
+describe('VLESS ML-KEM + xhttp conversion', () => {
+  it('parses encryption, xhttp mode/path and fingerprint from share link', () => {
+    const parsed = parseVless(MLKEM_URL);
+    expect(parsed.type).toBe('vless');
+    expect(parsed.encryption).toMatch(/^mlkem768x25519plus\.native\.0rtt\./);
+    expect(parsed.encryption.length).toBeGreaterThan(1000);
+    expect(parsed.flow).toBe('xtls-rprx-vision');
+    expect(parsed.transport?.type).toBe('xhttp');
+    expect(parsed.transport?.mode).toBe('auto');
+    expect(parsed.transport?.path).toBe('/test-xh');
+    expect(parsed.tls?.utls?.fingerprint).toBe('chrome');
+    expect(parsed.tls?.reality?.public_key).toBe('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+  });
+
+  it('exports encryption and xhttp-opts for Clash/mihomo', () => {
+    const parsed = parseVless(MLKEM_URL);
+    const clash = toClash(parsed);
+    expect(clash.encryption).toMatch(/^mlkem768x25519plus\.native\.0rtt\./);
+    expect(clash.network).toBe('xhttp');
+    expect(clash['xhttp-opts']).toEqual(
+      expect.objectContaining({
+        path: '/test-xh',
+        mode: 'auto'
+      })
+    );
+    expect(clash.flow).toBe('xtls-rprx-vision');
+    expect(clash['client-fingerprint']).toBe('chrome');
+    expect(clash['reality-opts']['public-key']).toBeTruthy();
+  });
+
+  it('round-trips Clash YAML encryption and xhttp-opts', () => {
+    const yamlProxy = {
+      name: 'pq-node',
+      type: 'vless',
+      server: '203.0.113.10',
+      port: 443,
+      uuid: '00000000-0000-4000-8000-000000000001',
+      encryption: 'mlkem768x25519plus.native.0rtt.abc',
+      flow: 'xtls-rprx-vision',
+      tls: true,
+      servername: 'example.com',
+      'client-fingerprint': 'chrome',
+      'reality-opts': {
+        'public-key': 'pk',
+        'short-id': 'sid'
+      },
+      network: 'xhttp',
+      'xhttp-opts': {
+        path: '/abc',
+        mode: 'auto'
+      }
+    };
+    const obj = convertYamlProxyToObject(yamlProxy);
+    expect(obj.encryption).toBe('mlkem768x25519plus.native.0rtt.abc');
+    expect(obj.transport?.type).toBe('xhttp');
+    expect(obj.transport?.mode).toBe('auto');
+    expect(obj.transport?.path).toBe('/abc');
+  });
+});
+
+describe('TLS insecure flag parsing', () => {
+  it('treats insecure=0 as skip-cert-verify false for TUIC', () => {
+    const clash = toClash(parseTuic(TUIC_SECURE_URL));
+    expect(clash['skip-cert-verify']).toBe(false);
+    expect(clash.sni).toBe('tuic.example.com');
+    expect(clash['congestion-controller']).toBe('bbr');
+  });
+
+  it('treats insecure=1 as skip-cert-verify true for TUIC', () => {
+    const clash = toClash(parseTuic(TUIC_INSECURE_URL));
+    expect(clash['skip-cert-verify']).toBe(true);
+    expect(clash.server).toBe('2001:db8::1');
+  });
+
+  it('treats insecure=0 as skip-cert-verify false for Hysteria2', () => {
+    const clash = toClash(parseHysteria2(HY2_SECURE_URL));
+    expect(clash['skip-cert-verify']).toBe(false);
+    expect(clash.sni).toBe('hy2.example.com');
+  });
+
+  it('keeps fingerprint and ws-opts for VLESS TLS share links', () => {
+    const clash = toClash(parseVless(VLESS_WS_URL));
+    expect(clash['client-fingerprint']).toBe('chrome');
+    expect(clash.network).toBe('ws');
+    expect(clash['ws-opts']?.path).toBe('/proxy');
+    expect(clash['skip-cert-verify']).toBe(true);
+    // encryption=none should not appear
+    expect(clash.encryption).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Preserve VLESS post-quantum `encryption` (e.g. `mlkem768x25519plus...`) and `xhttp-opts` (`path`/`mode`/`host`) when converting share links to Clash/mihomo.
- Keep `client-fingerprint` (`fp`) for VLESS/VMess/Trojan Clash export.
- Parse share-link `insecure=0/1` correctly with `parseBool` instead of truthy string checks.
- For **Clash/mihomo export only**, force `skip-cert-verify: true` so nodes that advertise `insecure=0` but fail strict certificate verification still work (common with public share links). Parsers still preserve the original flag for other targets.

## Motivation

1. Quantum VLESS share links were parsed as VLESS but lost `encryption` / incomplete `xhttp` options in Clash output, so mihomo could not use them.
2. `!!params.insecure` treated `"0"` as `true`, flipping `skip-cert-verify` incorrectly.
3. Even with correct `insecure=0` parsing, many real TUIC/Hysteria2 share nodes fail under mihomo's strict TLS verification while working in V2RayN; Clash export now prefers usability for multi-subscription conversion.

## Test plan

- [x] Full suite: `npx vitest run` — 31 files / 215 tests passed
- [x] Synthetic fixtures for ML-KEM + xhttp + insecure flags (`test/issue-vless-mlkem-xhttp.test.js`)
- [x] Manual smoke: VLESS (mlkem/xhttp/ws/reality), TUIC, Hysteria2, Trojan, SS, VMess share links
- [x] Confirmed Clash export sets `skip-cert-verify: true` for TUIC/Hy2 even when link has `insecure=0`

## Notes

- Scope is limited to parse + Clash export paths; no architecture changes.
- No real subscription credentials in tests (synthetic data only).