### PR TITLE
fix: pin sing-box rule-set downloads to DIRECT (#401, #408)

### DIFF
--- a/src/app/createApp.jsx
+++ b/src/app/createApp.jsx
@@ -474,14 +474,31 @@ function isSingboxLegacyConfig(version) {
     return version.minor < 12;
 }
 
+// 1.14 swaps rule-set download_detour for http_client, which older clients
+// reject as an unknown field, so it needs its own config tier.
+function isSingboxModernConfig(version) {
+    if (!version || Number.isNaN(version.major) || Number.isNaN(version.minor)) {
+        return false;
+    }
+    if (version.major !== 1) {
+        return version.major > 1;
+    }
+    return version.minor >= 14;
+}
+
+function resolveSingboxConfigTier(version) {
+    if (isSingboxLegacyConfig(version)) return '1.11';
+    return isSingboxModernConfig(version) ? '1.14' : '1.12';
+}
+
 function resolveSingboxConfigVersion(requestedVersion, userAgent) {
     const normalizedRequested = typeof requestedVersion === 'string' ? requestedVersion.trim().toLowerCase() : '';
     if (normalizedRequested && normalizedRequested !== 'auto') {
         if (normalizedRequested === 'legacy') return '1.11';
-        if (normalizedRequested === 'latest') return '1.12';
+        if (normalizedRequested === 'latest') return '1.14';
         const parsed = parseSemverLike(normalizedRequested);
         if (parsed) {
-            return isSingboxLegacyConfig(parsed) ? '1.11' : '1.12';
+            return resolveSingboxConfigTier(parsed);
         }
     }
 
@@ -490,7 +507,7 @@ function resolveSingboxConfigVersion(requestedVersion, userAgent) {
         const versionString = uaMatch?.[1];
         const parsed = versionString ? parseSemverLike(versionString) : null;
         if (parsed) {
-            return isSingboxLegacyConfig(parsed) ? '1.11' : '1.12';
+            return resolveSingboxConfigTier(parsed);
         }
     }
 

--- a/src/builders/SingboxConfigBuilder.js
+++ b/src/builders/SingboxConfigBuilder.js
@@ -6,6 +6,8 @@ import { addProxyWithDedup } from './helpers/proxyHelpers.js';
 import { buildSelectorMembers as buildSelectorMemberList, buildNodeSelectMembers, buildCustomRuleMembers, uniqueNames } from './helpers/groupBuilder.js';
 import { normalizeGroupName } from './helpers/groupNameUtils.js';
 
+const RULE_SET_HTTP_CLIENT_TAG = 'rule-set-download';
+
 export class SingboxConfigBuilder extends BaseConfigBuilder {
     constructor(inputString, selectedRules, customRules, baseConfig, lang, userAgent, groupByCountry = false, enableClashUI = false, externalController, externalUiDownloadUrl, singboxVersion = '1.12', includeAutoSelect = true) {
         const resolvedBaseConfig = baseConfig ?? SING_BOX_CONFIG;
@@ -18,7 +20,7 @@ export class SingboxConfigBuilder extends BaseConfigBuilder {
         this.enableClashUI = enableClashUI;
         this.externalController = externalController;
         this.externalUiDownloadUrl = externalUiDownloadUrl;
-        this.singboxVersion = singboxVersion;  // '1.11' or '1.12'
+        this.singboxVersion = singboxVersion;  // '1.11', '1.12' or '1.14'
 
         if (this.config?.dns?.servers?.length > 0) {
             this.config.dns.servers[0].detour = this.t('outboundNames.Node Select');
@@ -485,11 +487,37 @@ export class SingboxConfigBuilder extends BaseConfigBuilder {
         return { outbound: this.t(`outboundNames.${rule.outbound}`) };
     }
 
+    /**
+     * Pin remote rule-set downloads to DIRECT so fetching never depends on a
+     * proxy that may not be up yet (issue #408). sing-box 1.14 deprecates both
+     * the implicit default HTTP client and the download_detour field (removed
+     * in 1.16, issue #401), so >=1.14 gets an explicit shared HTTP client
+     * while older versions get the legacy per-rule-set field.
+     */
+    configureRuleSetDownload() {
+        if (this.singboxVersion === '1.14') {
+            if (this.config.route.default_http_client) {
+                return;
+            }
+            if (!Array.isArray(this.config.http_clients) || this.config.http_clients.length === 0) {
+                this.config.http_clients = [{ tag: RULE_SET_HTTP_CLIENT_TAG, detour: 'DIRECT' }];
+            }
+            this.config.route.default_http_client = this.config.http_clients[0].tag;
+            return;
+        }
+        this.config.route.rule_set.forEach(ruleSet => {
+            if (ruleSet?.type === 'remote' && !ruleSet.download_detour) {
+                ruleSet.download_detour = 'DIRECT';
+            }
+        });
+    }
+
     formatConfig() {
         const rules = generateRules(this.selectedRules, this.customRules);
         const { site_rule_sets, ip_rule_sets } = generateRuleSets(this.selectedRules, this.customRules);
 
         this.config.route.rule_set = [...site_rule_sets, ...ip_rule_sets];
+        this.configureRuleSetDownload();
 
         // Add outbound_providers if we have any
         if (this.providerUrls.length > 0) {

--- a/test/issue-401-rule-set-download.test.js
+++ b/test/issue-401-rule-set-download.test.js
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { SingboxConfigBuilder } from '../src/builders/SingboxConfigBuilder.js';
+import { SING_BOX_CONFIG } from '../src/config/index.js';
+import { createApp } from '../src/app/createApp.jsx';
+import { MemoryKVAdapter } from '../src/adapters/kv/memoryKv.js';
+
+/**
+ * Issues #401/#408: remote rule-sets must not rely on sing-box's implicit
+ * default HTTP client (deprecated in 1.14, removed in 1.16) and downloads
+ * should go DIRECT so fetching never depends on a proxy that is not up yet.
+ * <1.14 keeps the legacy download_detour field (http_client is an unknown
+ * field there and would fail config validation); >=1.14 gets an explicit
+ * shared http_clients entry + route.default_http_client.
+ */
+describe('sing-box rule-set download detour', () => {
+    const vlessUrl = 'vless://12345678-1234-1234-1234-123456789abc@example.com:443?security=tls&sni=example.com#TestVless';
+
+    const buildWithVersion = async (singboxVersion, baseConfig = null) => {
+        const builder = new SingboxConfigBuilder(
+            vlessUrl, [], [], baseConfig, 'zh-CN', null, false,
+            false, undefined, undefined, singboxVersion
+        );
+        return builder.build();
+    };
+
+    it('adds download_detour to every remote rule-set on the default 1.12 tier', async () => {
+        const result = await buildWithVersion('1.12');
+        const ruleSets = result.route.rule_set;
+        expect(ruleSets.length).toBeGreaterThan(0);
+        ruleSets.forEach(rs => {
+            if (rs.type === 'remote') {
+                expect(rs.download_detour).toBe('DIRECT');
+                expect(rs).not.toHaveProperty('http_client');
+            }
+        });
+        expect(result).not.toHaveProperty('http_clients');
+        expect(result.route).not.toHaveProperty('default_http_client');
+    });
+
+    it('adds download_detour on the 1.11 tier', async () => {
+        const result = await buildWithVersion('1.11');
+        const ruleSets = result.route.rule_set;
+        expect(ruleSets.length).toBeGreaterThan(0);
+        ruleSets.forEach(rs => {
+            if (rs.type === 'remote') {
+                expect(rs.download_detour).toBe('DIRECT');
+                expect(rs).not.toHaveProperty('http_client');
+            }
+        });
+    });
+
+    it('uses a shared http_client instead of download_detour on the 1.14 tier', async () => {
+        const result = await buildWithVersion('1.14');
+        result.route.rule_set.forEach(rs => {
+            expect(rs).not.toHaveProperty('download_detour');
+            expect(rs).not.toHaveProperty('http_client');
+        });
+        expect(result.http_clients).toEqual([{ tag: 'rule-set-download', detour: 'DIRECT' }]);
+        expect(result.route.default_http_client).toBe('rule-set-download');
+    });
+
+    it('respects an existing http_clients entry from the base config on the 1.14 tier', async () => {
+        const baseConfig = {
+            ...SING_BOX_CONFIG,
+            http_clients: [{ tag: 'my-client', detour: 'DIRECT' }]
+        };
+        const result = await buildWithVersion('1.14', baseConfig);
+        expect(result.http_clients).toEqual([{ tag: 'my-client', detour: 'DIRECT' }]);
+        expect(result.route.default_http_client).toBe('my-client');
+    });
+});
+
+describe('sing-box version tier resolution', () => {
+    const vmessUrl = 'vmess://ew0KICAidiI6ICIyIiwNCiAgInBzIjogInRlc3QiLA0KICAiYWRkIjogIjEuMS4xLjEiLA0KICAicG9ydCI6ICI0NDMiLA0KICAiaWQiOiAiYWRkNjY2NjYtODg4OC04ODg4LTg4ODgtODg4ODg4ODg4ODg4IiwNCiAgImFpZCI6ICIwIiwNCiAgInNjeSI6ICJhdXRvIiwNCiAgIm5ldCI6ICJ3cyIsDQogICJ0eXBlIjogIm5vbmUiLA0KICAiaG9zdCI6ICIiLA0KICAicGF0aCI6ICIvIiwNCiAgInRscyI6ICJ0bHMiDQp9';
+
+    const createTestApp = () => createApp({
+        kv: new MemoryKVAdapter(),
+        assetFetcher: null,
+        logger: console,
+        config: { configTtlSeconds: 60, shortLinkTtlSeconds: null }
+    });
+
+    const fetchConfig = (query = '', headers) => {
+        const app = createTestApp();
+        return app.request(`http://localhost/singbox?config=${encodeURIComponent(vmessUrl)}${query}`, { headers });
+    };
+
+    it('returns the 1.14 shape for sb_ver=1.14', async () => {
+        const res = await fetchConfig('&sb_ver=1.14');
+        expect(res.status).toBe(200);
+        const json = await res.json();
+        expect(json.route.default_http_client).toBe('rule-set-download');
+    });
+
+    it('returns the 1.14 shape for a sing-box 1.14 user-agent', async () => {
+        const res = await fetchConfig('', {
+            'User-Agent': 'SFA/1.14.0 (100; sing-box 1.14.0; language zh_Hans_CN)'
+        });
+        expect(res.status).toBe(200);
+        const json = await res.json();
+        expect(json.route.default_http_client).toBe('rule-set-download');
+    });
+
+    it('maps sb_ver=latest to the newest tier', async () => {
+        const res = await fetchConfig('&sb_ver=latest');
+        expect(res.status).toBe(200);
+        const json = await res.json();
+        expect(json.route.default_http_client).toBe('rule-set-download');
+    });
+
+    it('keeps download_detour for sb_ver=1.12', async () => {
+        const res = await fetchConfig('&sb_ver=1.12');
+        expect(res.status).toBe(200);
+        const json = await res.json();
+        expect(json).not.toHaveProperty('http_clients');
+        json.route.rule_set.forEach(rs => {
+            if (rs.type === 'remote') {
+                expect(rs.download_detour).toBe('DIRECT');
+            }
+        });
+    });
+
+    it('falls back to the safe 1.12 tier when no version is detectable', async () => {
+        const res = await fetchConfig();
+        expect(res.status).toBe(200);
+        const json = await res.json();
+        expect(json).not.toHaveProperty('http_clients');
+        json.route.rule_set.forEach(rs => {
+            if (rs.type === 'remote') {
+                expect(rs.download_detour).toBe('DIRECT');
+            }
+        });
+    });
+});


### PR DESCRIPTION
## 问题

Closes #401
Closes #408

- sing-box 1.14 起，remote rule-set 的隐式默认 HTTP client 和 `download_detour` 字段均被弃用，1.16 将移除 —— 当前生成的配置在 1.14+ 有弃用警告，1.16 会无法启动（#401）
- 未显式指定下载出站时，rule-set 下载走路由表进入代理，代理未就绪或网络受限地区启动直接报 EOF（#408）

## 改动

按 sing-box 版本分档（`http_client` 在 <1.14 上是未知字段会 FATAL，无法统一使用）：

- **<1.14（1.11/1.12 档）**：每个 remote rule-set 加 `download_detour: 'DIRECT'` —— 修 EOF，这些版本上字段未弃用、无警告
- **≥1.14（新增档位）**：按官方迁移建议输出顶层 `http_clients` + `route.default_http_client`（detour 为 `DIRECT`），rule_set 本身不加字段 —— 两条弃用警告同时消除，且面向 1.16；base config 已有 `http_clients` 时尊重现有配置
- `resolveSingboxConfigVersion()` 扩展为三档：UA / `sb_ver` ≥1.14 → 新档；`sb_ver=latest` 改指新档；无法识别版本时回落 1.12 安全档（1.14/1.15 客户端拿到仅警告，功能正常）

## 测试

- 新增 `test/issue-401-rule-set-download.test.js`（9 个用例）：builder 层各档位输出形态 + 已有 `http_clients` 不覆盖；路由层 `sb_ver` / UA / 默认回落
- 全量 `npm test`：31 文件 217 用例通过