### PR TITLE
fix: build clash country groups over proxy-providers via use+filter (#403)

### DIFF
--- a/src/builders/BaseConfigBuilder.js
+++ b/src/builders/BaseConfigBuilder.js
@@ -15,6 +15,7 @@ export class BaseConfigBuilder {
         this.groupByCountry = groupByCountry;
         this.includeAutoSelect = includeAutoSelect;
         this.providerUrls = [];  // URLs to use as providers (auto-sync)
+        this.providerNodeNames = [];  // node names from provider subscriptions, for country enumeration only
         this.autoProviderDescriptors = undefined;
         this.subscriptionUserinfo = undefined;
     }
@@ -102,6 +103,9 @@ export class BaseConfigBuilder {
                             // If format is compatible with target client, use as provider
                             if (this.isCompatibleProviderFormat(format)) {
                                 this.providerUrls.push(originalUrl);
+                                // Content is already fetched; keep node names so country
+                                // groups can be built over provider members later.
+                                await this.collectProviderNodeNames(content);
                                 continue;  // Skip parsing, will be used as provider
                             }
 
@@ -184,6 +188,25 @@ export class BaseConfigBuilder {
      */
     isCompatibleProviderFormat(format) {
         return false;  // Default: no provider support
+    }
+
+    /**
+     * Extract node names from an already-fetched provider subscription.
+     * Names are only used to enumerate countries for group filters; the nodes
+     * themselves stay remote. Best-effort: provider mode must not fail here.
+     */
+    async collectProviderNodeNames(content) {
+        try {
+            const { parseSubscriptionContent } = await import('../parsers/subscription/subscriptionContentParser.js');
+            const result = parseSubscriptionContent(content);
+            const proxies = Array.isArray(result?.proxies) ? result.proxies : [];
+            proxies.forEach(proxy => {
+                const name = proxy?.tag ?? proxy?.name;
+                if (typeof name === 'string' && name.trim()) {
+                    this.providerNodeNames.push(name.trim());
+                }
+            });
+        } catch (_) { }
     }
 
     getAutoProviderDescriptors(reservedNames = []) {

--- a/src/builders/ClashConfigBuilder.js
+++ b/src/builders/ClashConfigBuilder.js
@@ -1,7 +1,7 @@
 import yaml from 'js-yaml';
 import { CLASH_CONFIG, generateRules, generateClashRuleSets, getOutbounds, PREDEFINED_RULE_SETS, DIRECT_DEFAULT_RULES } from '../config/index.js';
 import { BaseConfigBuilder } from './BaseConfigBuilder.js';
-import { deepCopy, groupProxiesByCountry } from '../utils.js';
+import { deepCopy, groupProxiesByCountry, buildCountryNameFilter } from '../utils.js';
 import { addProxyWithDedup } from './helpers/proxyHelpers.js';
 import { buildSelectorMembers, buildNodeSelectMembers, buildCustomRuleMembers, uniqueNames } from './helpers/groupBuilder.js';
 import { emitClashRules, sanitizeClashProxyGroups } from './helpers/clashConfigUtils.js';
@@ -471,6 +471,21 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
             getName: proxy => this.getProxyName(proxy)
         });
 
+        // Provider mode leaves no inline proxies, but mihomo can filter provider
+        // members per group (`use` + `filter`), so enumerate countries from the
+        // names collected at fetch time and reference the providers instead.
+        const providerNames = this.getAllProviderNames();
+        if (providerNames.length > 0 && this.providerNodeNames.length > 0) {
+            const providerCountryGroups = groupProxiesByCountry(this.providerNodeNames, {
+                getName: name => name
+            });
+            Object.keys(providerCountryGroups).forEach(country => {
+                if (!countryGroups[country]) {
+                    countryGroups[country] = { ...providerCountryGroups[country], proxies: [] };
+                }
+            });
+        }
+
         const existingNames = new Set((this.config['proxy-groups'] || []).map(g => normalizeGroupName(g?.name)).filter(Boolean));
 
         const manualProxyNames = proxies.map(p => p?.name).filter(Boolean);
@@ -497,7 +512,7 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
         const countryGroupNames = [];
 
         countries.forEach(country => {
-            const { emoji, name, proxies } = countryGroups[country];
+            const { emoji, name, aliases, proxies } = countryGroups[country];
             const groupName = `${emoji} ${name}`;
             const norm = normalizeGroupName(groupName);
             if (!existingNames.has(norm)) {
@@ -509,10 +524,14 @@ export class ClashConfigBuilder extends BaseConfigBuilder {
                     interval: 300,
                     lazy: false
                 };
-                // Add 'use' field if we have proxy-providers
-                const providerNames = this.getAllProviderNames();
+                // Add 'use' field if we have proxy-providers, narrowed to this
+                // country so provider members don't leak into every group
                 if (providerNames.length > 0) {
                     group.use = providerNames;
+                    const filter = buildCountryNameFilter({ emoji, aliases });
+                    if (filter) {
+                        group.filter = filter;
+                    }
                 }
                 this.config['proxy-groups'].push(group);
                 existingNames.add(norm);

--- a/src/utils.js
+++ b/src/utils.js
@@ -411,3 +411,24 @@ export function parseCountryFromNodeName(nodeName) {
 
 	return null;
 }
+
+// Build a mihomo proxy-group `filter` regex matching node names of one country.
+// Mirrors the classification patterns in parseCountryFromNodeName (same escaping
+// and \b rules) so runtime filtering agrees with build-time grouping; the flag
+// emoji is added because mihomo filters raw names, which often carry it.
+export function buildCountryNameFilter({ emoji, aliases } = {}) {
+	const patterns = (aliases || []).map(alias => {
+		const escaped = alias.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+		if (alias.length <= 3 && /^[A-Za-z]+$/.test(alias)) {
+			return `\\b${escaped}\\b`;
+		}
+		return escaped;
+	});
+	if (emoji) {
+		patterns.push(emoji);
+	}
+	if (patterns.length === 0) {
+		return null;
+	}
+	return `(?i)${patterns.join('|')}`;
+}

--- a/test/issue-403-provider-country-group.test.js
+++ b/test/issue-403-provider-country-group.test.js
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import yaml from 'js-yaml';
+
+vi.mock('../src/parsers/subscription/httpSubscriptionFetcher.js', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        fetchSubscriptionWithFormat: vi.fn()
+    };
+});
+
+import { fetchSubscriptionWithFormat } from '../src/parsers/subscription/httpSubscriptionFetcher.js';
+import { ClashConfigBuilder } from '../src/builders/ClashConfigBuilder.js';
+
+/**
+ * Issue #403: a Clash YAML subscription goes into proxy-provider mode, which
+ * used to skip parsing entirely, so no country groups were ever created.
+ * mihomo supports per-group `use` + `filter`, so country groups are now built
+ * over provider members using the node names seen at fetch time.
+ */
+const mockClashYaml = `
+proxies:
+  - name: 香港节点01
+    type: ss
+    server: hk.example.com
+    port: 443
+    cipher: aes-128-gcm
+    password: test123
+  - name: 日本节点01
+    type: ss
+    server: jp.example.com
+    port: 443
+    cipher: aes-128-gcm
+    password: test456
+`;
+
+const SUB_URL = 'https://example.com/clash-sub?token=xxx';
+
+const mockClashSubscription = () => {
+    fetchSubscriptionWithFormat.mockResolvedValue({
+        content: mockClashYaml,
+        format: 'clash',
+        url: SUB_URL
+    });
+};
+
+const findGroup = (config, name) => (config['proxy-groups'] || []).find(g => g && g.name === name);
+
+// mihomo compiles filters with RE2 where (?i) is valid; JS needs the flag instead
+const toJsRegex = (filter) => new RegExp(filter.replace(/^\(\?i\)/, ''), 'i');
+
+describe('issue #403: country groups in proxy-provider mode', () => {
+    afterEach(() => vi.clearAllMocks());
+
+    it('creates country groups with use+filter when input is a Clash subscription', async () => {
+        mockClashSubscription();
+        const builder = new ClashConfigBuilder(SUB_URL, [], [], null, 'zh-CN', 'test-agent', true);
+        const config = yaml.load(await builder.build());
+
+        expect(config['proxy-providers']).toBeDefined();
+
+        const hkGroup = findGroup(config, '🇭🇰 Hong Kong');
+        expect(hkGroup).toBeDefined();
+        expect(hkGroup.type).toBe('url-test');
+        // no inline nodes in pure provider mode; membership comes from the provider
+        expect(hkGroup.proxies || []).toHaveLength(0);
+        expect(hkGroup.use).toEqual(Object.keys(config['proxy-providers']));
+        expect(hkGroup.filter).toBeDefined();
+
+        const jpGroup = findGroup(config, '🇯🇵 Japan');
+        expect(jpGroup).toBeDefined();
+        expect(jpGroup.use).toEqual(hkGroup.use);
+        expect(jpGroup.filter).toBeDefined();
+        expect(jpGroup.filter).not.toBe(hkGroup.filter);
+    });
+
+    it('filter regex matches the provider node names of its own country only', async () => {
+        mockClashSubscription();
+        const builder = new ClashConfigBuilder(SUB_URL, [], [], null, 'zh-CN', 'test-agent', true);
+        const config = yaml.load(await builder.build());
+
+        const hkFilter = toJsRegex(findGroup(config, '🇭🇰 Hong Kong').filter);
+        const jpFilter = toJsRegex(findGroup(config, '🇯🇵 Japan').filter);
+
+        expect(hkFilter.test('香港节点01')).toBe(true);
+        expect(hkFilter.test('日本节点01')).toBe(false);
+        expect(jpFilter.test('日本节点01')).toBe(true);
+        expect(jpFilter.test('香港节点01')).toBe(false);
+        // word-boundary rule: "plus" must not match the US alias
+        const usYaml = mockClashYaml.replace('日本节点01', 'US-Node');
+        fetchSubscriptionWithFormat.mockResolvedValue({ content: usYaml, format: 'clash', url: SUB_URL });
+        const builder2 = new ClashConfigBuilder(SUB_URL, [], [], null, 'zh-CN', 'test-agent', true);
+        const config2 = yaml.load(await builder2.build());
+        const usFilter = toJsRegex(findGroup(config2, '🇺🇸 United States').filter);
+        expect(usFilter.test('plus-node')).toBe(false);
+        expect(usFilter.test('US-Node')).toBe(true);
+    });
+
+    it('keeps inline proxies and narrows provider members in mixed mode', async () => {
+        mockClashSubscription();
+        const inline = 'ss://YWVzLTEyOC1nY206dGVzdA@example.com:443#HK-Inline';
+        const builder = new ClashConfigBuilder(`${inline}\n${SUB_URL}`, [], [], null, 'zh-CN', 'test-agent', true);
+        const config = yaml.load(await builder.build());
+
+        const hkGroup = findGroup(config, '🇭🇰 Hong Kong');
+        expect(hkGroup.proxies).toContain('HK-Inline');
+        expect(hkGroup.use).toBeDefined();
+        // filter prevents every provider node from landing in every country group
+        expect(hkGroup.filter).toBeDefined();
+
+        // Japan exists only via the provider, so no inline members
+        const jpGroup = findGroup(config, '🇯🇵 Japan');
+        expect(jpGroup.proxies || []).toHaveLength(0);
+        expect(jpGroup.filter).toBeDefined();
+    });
+
+    it('does not add filter when there are no providers (unchanged legacy path)', async () => {
+        const input = 'ss://YWVzLTEyOC1nY206dGVzdA@example.com:443#香港节点';
+        const builder = new ClashConfigBuilder(input, [], [], null, 'zh-CN', 'test-agent', true);
+        const config = yaml.load(await builder.build());
+
+        const hkGroup = findGroup(config, '🇭🇰 Hong Kong');
+        expect(hkGroup).toBeDefined();
+        expect(hkGroup.use).toBeUndefined();
+        expect(hkGroup.filter).toBeUndefined();
+    });
+
+    it('references the new country groups from the Node Select group', async () => {
+        mockClashSubscription();
+        const builder = new ClashConfigBuilder(SUB_URL, [], [], null, 'zh-CN', 'test-agent', true);
+        const config = yaml.load(await builder.build());
+
+        const nodeSelect = findGroup(config, '🚀 节点选择');
+        expect(nodeSelect).toBeDefined();
+        expect(nodeSelect.proxies).toContain('🇭🇰 Hong Kong');
+        expect(nodeSelect.proxies).toContain('🇯🇵 Japan');
+    });
+});


### PR DESCRIPTION
## 问题

Closes #403

输入 Clash YAML 订阅并开启国家分组时，订阅进入 proxy-provider 模式（`BaseConfigBuilder` 跳过解析），`addCountryGroups()` 拿到空的 proxies 列表，一个国家分组都不生成 —— 而 Auto Select 因为有 `use` 分支表现正常。

## 方案

经查 [mihomo 官方文档](https://wiki.metacubex.one/en/config/proxy-groups/)，proxy-group 的 `filter` 字段可与 `use` 同组使用，按正则过滤 provider 成员 —— 这是 provider 模式下国家分组的原生机制（也是机场订阅生成器的通用做法），无需回退全解析、保留 provider 自动同步能力：

- provider 分支保留已 fetch 订阅的**节点名**（仅用于国家枚举，节点不进配置，零额外网络开销，解析失败不影响主流程）
- 国家枚举 = 内联节点 ∪ provider 节点名；每个国家分组输出 `use: <providers>` + `filter: <该国正则>`
- filter 正则由 `COUNTRY_DATA` 同一别名表构造（同样的转义与 `\b` 短别名规则，外加国旗 emoji），保证编译期分组与运行时过滤一致

**顺带修复**：混合模式（内联节点 + provider）此前每个国家分组不加 filter 直接 `use`，导致全部 provider 节点泄漏进每个国家分组。

## 测试

- 新增 `test/issue-403-provider-country-group.test.js`（5 用例）：纯 provider 模式分组形态、filter 只匹配本国节点（含 `plus` 不匹配 `US` 边界）、混合模式收窄、无 provider 时旧路径不变、Node Select 引用新分组
- 全量 `npm test`：32 文件 222 用例通过
- 合并后已用 mihomo 二进制对生成配置做 `-t` 冒烟校验