### PR TITLE
fix: isolate stored configs by output format

### DIFF
--- a/src/app/createApp.jsx
+++ b/src/app/createApp.jsx
@@ -91,7 +91,7 @@ export function createApp(bindings = {}) {
             const singboxConfigVersion = resolveSingboxConfigVersion(requestedSingboxVersion, requestUserAgent);
 
             let baseConfig = singboxConfigVersion === '1.11' ? SING_BOX_CONFIG_V1_11 : SING_BOX_CONFIG;
-            if (configId) {
+            if (configId?.startsWith('singbox_')) {
                 const storage = requireConfigStorage(services.configStorage);
                 const storedConfig = await storage.getConfigById(configId);
                 if (storedConfig) {
@@ -143,7 +143,7 @@ export function createApp(bindings = {}) {
             const lang = c.get('lang');
 
             let baseConfig;
-            if (configId) {
+            if (configId?.startsWith('clash_')) {
                 const storage = requireConfigStorage(services.configStorage);
                 baseConfig = await storage.getConfigById(configId);
             }
@@ -189,7 +189,7 @@ export function createApp(bindings = {}) {
             const lang = c.get('lang');
 
             let baseConfig;
-            if (configId) {
+            if (configId?.startsWith('surge_')) {
                 const storage = requireConfigStorage(services.configStorage);
                 baseConfig = await storage.getConfigById(configId);
             }

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -36,6 +36,19 @@ describe('Worker', () => {
         expect(json).toHaveProperty('outbounds');
     });
 
+    it('GET /singbox ignores a Clash base config ID', async () => {
+        const kv = new MemoryKVAdapter();
+        await kv.put('clash_test', JSON.stringify({
+            'proxy-groups': [{ name: 'Custom', type: 'select', proxies: ['DIRECT'] }]
+        }));
+        const app = createTestApp({ kv });
+        const config = 'vmess://ew0KICAidiI6ICIyIiwNCiAgInBzIjogInRlc3QiLA0KICAiYWRkIjogIjEuMS4xLjEiLA0KICAicG9ydCI6ICI0NDMiLA0KICAiaWQiOiAiYWRkNjY2NjYtODg4OC04ODg4LTg4ODgtODg4ODg4ODg4ODg4IiwNCiAgImFpZCI6ICIwIiwNCiAgInNjeSI6ICJhdXRvIiwNCiAgIm5ldCI6ICJ3cyIsDQogICJ0eXBlIjogIm5vbmUiLA0KICAiaG9zdCI6ICIiLA0KICAicGF0aCI6ICIvIiwNCiAgInRscyI6ICJ0bHMiDQp9';
+        const res = await app.request(`http://localhost/singbox?config=${encodeURIComponent(config)}&configId=clash_test`);
+
+        expect(res.status).toBe(200);
+        expect(await res.json()).toHaveProperty('route.rule_set');
+    });
+
     it('GET /singbox returns legacy config for sing-box 1.11 UA', async () => {
         const app = createTestApp();
         const config = 'vmess://ew0KICAidiI6ICIyIiwNCiAgInBzIjogInRlc3QiLA0KICAiYWRkIjogIjEuMS4xLjEiLA0KICAicG9ydCI6ICI0NDMiLA0KICAiaWQiOiAiYWRkNjY2NjYtODg4OC04ODg4LTg4ODgtODg4ODg4ODg4ODg4IiwNCiAgImFpZCI6ICIwIiwNCiAgInNjeSI6ICJhdXRvIiwNCiAgIm5ldCI6ICJ3cyIsDQogICJ0eXBlIjogIm5vbmUiLA0KICAiaG9zdCI6ICIiLA0KICAicGF0aCI6ICIvIiwNCiAgInRscyI6ICJ0bHMiDQp9';


### PR DESCRIPTION
## Summary

Only load a stored base config when its ID belongs to the requested output format.

## Problem

All conversion routes previously accepted any `configId`. Supplying a Clash config ID to `/singbox` could replace the Sing-box base config and yield an invalid or incomplete response.

## Change

- Scope stored config lookup to `singbox_`, `clash_`, or `surge_` IDs.
- Add a regression test for a Clash ID on `/singbox`.

## Validation

`node:22 … vitest run` — 32 files, 223 tests passed.

## Compatibility / rollback

Correct-format IDs keep existing behavior; mismatched IDs now use the normal format base config. Revert this commit to roll back; no migration or config rewrite.