### PR TITLE
fix: deduplicate exact proxy names

### DIFF
--- a/src/builders/helpers/proxyHelpers.js
+++ b/src/builders/helpers/proxyHelpers.js
@@ -24,18 +24,16 @@ export function addProxyWithDedup(collection, proxy, { getName = defaultGetName,
 
     let candidate = proxy;
     const targetName = getName(candidate) || '';
-    const similarProxies = collection.filter(item => {
-        const name = getName(item) || '';
-        return targetName && name.includes(targetName);
-    });
-
     const hasIdentical = collection.some(item => isSame(item, candidate));
     if (hasIdentical) {
         return;
     }
 
-    if (similarProxies.length > 0 && typeof setName === 'function' && targetName) {
-        const updated = setName(candidate, `${targetName} ${similarProxies.length + 1}`);
+    const usedNames = new Set(collection.map(item => getName(item) || ''));
+    if (usedNames.has(targetName) && typeof setName === 'function' && targetName) {
+        let suffix = 2;
+        while (usedNames.has(`${targetName} ${suffix}`)) suffix += 1;
+        const updated = setName(candidate, `${targetName} ${suffix}`);
         if (typeof updated !== 'undefined') {
             candidate = updated;
         }

--- a/test/proxy-helpers.test.js
+++ b/test/proxy-helpers.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { addProxyWithDedup } from '../src/builders/helpers/proxyHelpers.js';
+
+describe('addProxyWithDedup', () => {
+    it('renames exact duplicates without treating substrings as duplicates', () => {
+        const proxies = [];
+
+        addProxyWithDedup(proxies, { name: 'edge-hy2', server: 'hy2.example' });
+        addProxyWithDedup(proxies, { name: 'edge', server: 'reality.example' });
+        addProxyWithDedup(proxies, { name: 'edge', server: 'ws-1.example' });
+        addProxyWithDedup(proxies, { name: 'edge', server: 'ws-2.example' });
+
+        expect(proxies.map(proxy => proxy.name)).toEqual([
+            'edge-hy2',
+            'edge',
+            'edge 2',
+            'edge 3'
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary

Treat only exact proxy-name matches as name conflicts.

## Problem

The old substring check made names such as `edge-hy2` collide with `edge`, so a distinct first `edge` was renamed unnecessarily. Counting substring matches could also reuse a suffix after gaps.

## Change

- Keep structural duplicate filtering unchanged.
- Use exact occupied names and select the first free numeric suffix.
- Add regression coverage.

## Validation

`node:22 … vitest run` — 33 files, 223 tests passed.

## Compatibility / rollback

Existing exact-name duplicates continue to get deterministic suffixes; only unrelated substring names stop colliding. Revert this commit to roll back.