### PR TITLE
fix: preserve zero config TTL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_KEY_PREFIX: sublink
+      # Set to 0 to keep stored configs without automatic expiration.
       CONFIG_TTL_SECONDS: 2592000
     depends_on:
       - redis

--- a/src/runtime/node.js
+++ b/src/runtime/node.js
@@ -10,7 +10,7 @@ export function createNodeRuntime(env = process.env) {
         assetFetcher: createFileAssetFetcher(env.STATIC_DIR || 'public'),
         logger: console,
         config: {
-            configTtlSeconds: parseNumber(env.CONFIG_TTL_SECONDS) || undefined,
+            configTtlSeconds: parseNumber(env.CONFIG_TTL_SECONDS) ?? undefined,
             shortLinkTtlSeconds: parseNumber(env.SHORT_LINK_TTL_SECONDS) || null
         }
     };

--- a/test/node-runtime.test.js
+++ b/test/node-runtime.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('ioredis', () => ({ default: class Redis {} }));
+
+describe('createNodeRuntime', () => {
+    it('preserves zero as the no-expiration config TTL', async () => {
+        const { createNodeRuntime } = await import('../src/runtime/node.js');
+        const runtime = createNodeRuntime({
+            CONFIG_TTL_SECONDS: '0',
+            DISABLE_MEMORY_KV: 'true'
+        });
+
+        expect(runtime.config.configTtlSeconds).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary

Preserve `CONFIG_TTL_SECONDS=0` as an explicit no-expiration setting in the Node runtime.

## Problem

`parseNumber(...) || undefined` discarded parsed zero. Runtime normalization then used the default 30-day config TTL, contrary to the storage layer’s established zero/no-expiration behavior.

## Change

- Use nullish fallback so zero remains zero.
- Document zero in the Compose example.
- Add a regression test.

## Validation

`node:22 … vitest run` — 33 files, 223 tests passed.

## Compatibility / rollback

Unset/invalid values still use the existing default; only explicit zero changes behavior to no automatic expiry. Revert this commit to roll back; no migration required.